### PR TITLE
Fix base URL selection for SunPlanner links

### DIFF
--- a/sunplanner.js
+++ b/sunplanner.js
@@ -7,6 +7,23 @@
   var TZ           = CFG.TZ || (Intl.DateTimeFormat().resolvedOptions().timeZone || 'Europe/Warsaw');
   var REST_URL     = CFG.REST_URL || '';
   var SITE_ORIGIN  = CFG.SITE_ORIGIN || '';
+  var BASE_URL = (function(){
+    function stripQueryAndHash(url){ return url.replace(/[?#].*$/, ''); }
+    var locOrigin = location.origin || (location.protocol + '//' + location.host);
+    var locPath = location.pathname || '/';
+    var defaultBase = stripQueryAndHash(locOrigin + locPath);
+    if(SITE_ORIGIN){
+      try {
+        var siteUrl = new URL(SITE_ORIGIN, locOrigin);
+        var path = siteUrl.pathname || '/';
+        var isDedicated = (siteUrl.origin !== locOrigin) || (path !== '/' && path !== '');
+        if(isDedicated){
+          return stripQueryAndHash(siteUrl.origin + path);
+        }
+      } catch(e){}
+    }
+    return defaultBase;
+  })();
 
   var root = document.getElementById('sunplanner-app');
   if(!root){ console.warn('SunPlanner: brak #sunplanner-app'); return; }
@@ -1031,7 +1048,7 @@
 
   // link
   function updateLink(){
-    var url = location.origin + location.pathname + '?sp=' + b64url.enc(packState());
+    var url = BASE_URL + '?sp=' + b64url.enc(packState());
     history.replaceState(null,'',url);
     var linkEl=$('#sp-link'); if(linkEl) linkEl.textContent = url;
     if(shortLinkValue){


### PR DESCRIPTION
## Summary
- compute BASE_URL from the current page location and only fall back to SITE_ORIGIN when it targets a dedicated planner landing page
- keep updateLink() based on the normalized BASE_URL so shared and copied URLs stay on the planner page

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2b56c13cc8322b58e8f5012cf84ef