### PR TITLE
Refine base URL resolution for planner

### DIFF
--- a/sunplanner.js
+++ b/sunplanner.js
@@ -12,17 +12,22 @@
     var locOrigin = location.origin || (location.protocol + '//' + location.host);
     var locPath = location.pathname || '/';
     var defaultBase = stripQueryAndHash(locOrigin + locPath);
-    if(SITE_ORIGIN){
-      try {
-        var siteUrl = new URL(SITE_ORIGIN, locOrigin);
-        var path = siteUrl.pathname || '/';
-        var isDedicated = (siteUrl.origin !== locOrigin) || (path !== '/' && path !== '');
-        if(isDedicated){
-          return stripQueryAndHash(siteUrl.origin + path);
-        }
-      } catch(e){}
+    if(!SITE_ORIGIN){
+      return defaultBase;
     }
-    return defaultBase;
+
+    var siteBase = null;
+    try {
+      var siteUrl = new URL(SITE_ORIGIN, locOrigin);
+      var path = siteUrl.pathname || '/';
+      var isDedicatedHost = siteUrl.origin !== locOrigin;
+      var isDedicatedPath = (path !== '/' && path !== '');
+      if(isDedicatedHost || isDedicatedPath){
+        siteBase = stripQueryAndHash(siteUrl.origin + path);
+      }
+    } catch(e){}
+
+    return siteBase || defaultBase;
   })();
 
   var root = document.getElementById('sunplanner-app');


### PR DESCRIPTION
## Summary
- ensure the planner base URL defaults to the current location without query/hash
- only fall back to the configured SITE_ORIGIN when it targets a dedicated planner host or path

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2b85a8a288322871ab315b65b562b