### PR TITLE
Improve planner UI accents and fix sharing

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -22,7 +22,7 @@
 .glow-info{flex:0 0 200px;min-width:180px;background:linear-gradient(135deg,rgba(253,230,138,.85),rgba(253,186,116,.85));border-radius:16px;padding:1rem;color:#78350f;display:flex;flex-direction:column;justify-content:center;gap:.35rem;box-shadow:0 4px 14px rgba(253,186,116,.25)}
 .glow-info.align-right{background:linear-gradient(135deg,rgba(191,219,254,.85),rgba(147,197,253,.85));color:#1e3a8a;text-align:right;align-items:flex-end}
 .glow-info h4{margin:0;font-size:1rem;font-weight:600}
-.glow-line{margin:0;font-size:.9rem;font-weight:600}
+.glow-line{margin:0;font-size:.95rem;font-weight:600;line-height:1.35;text-shadow:0 1px 0 rgba(255,255,255,.45);letter-spacing:.01em}
 @media(min-width:980px){.cards{grid-template-columns:1fr}.grid2{grid-template-columns:1fr 1fr}}
 .muted{color:#6b7280;font-size:.9rem}
 .badge{margin:.35rem 0;padding:.25rem .5rem;background:#f3f4f6;border-radius:6px;display:inline-block;font-size:.85rem;color:#374151}
@@ -66,9 +66,7 @@
   .toolbar{flex-direction:column;align-items:flex-start}
   .toolbar .btn{width:100%}
   .share-row .btn{min-width:140px}
-codex/add-new-features-and-prepare-code-7ga067
 }
 @media(max-width:780px){
   .glow-info,.glow-info.align-right{flex:1 1 100%;text-align:left;align-items:flex-start}
-=======
 }

--- a/sunplanner.js
+++ b/sunplanner.js
@@ -1,25 +1,12 @@
-
 /* SunPlanner v1.7.0 - rozbudowany planer z wykresem słońca, radarową warstwą mapy, autosave i eksportami */
 (function(){
   var CFG = window.SUNPLANNER_CFG || {};
-=======
-/* SunPlanner v1.7.0 - rozbudowany planner z wykresem slonca, radarowa warstwa mapy, autosave i eksportami */
-(function(){
-  var CFG = window.SUNPLANNER_CFG || {};
-
   var GMAPS_KEY    = CFG.GMAPS_KEY || '';
   var CSE_ID       = CFG.CSE_ID || '';
   var UNSPLASH_KEY = CFG.UNSPLASH_KEY || '';
   var TZ           = CFG.TZ || (Intl.DateTimeFormat().resolvedOptions().timeZone || 'Europe/Warsaw');
   var REST_URL     = CFG.REST_URL || '';
   var SITE_ORIGIN  = CFG.SITE_ORIGIN || '';
-
-  var BASE_URL = (SITE_ORIGIN && SITE_ORIGIN.split('?')[0]) || (location.origin + location.pathname.split('?')[0]);
-
-  var root = document.getElementById('sunplanner-app');
-  if(!root){ console.warn('SunPlanner: brak #sunplanner-app'); return; }
-
-
   var BASE_URL = (function(){
     function stripQueryAndHash(url){ return url.replace(/[?#].*$/, ''); }
     var locOrigin = location.origin || (location.protocol + '//' + location.host);
@@ -46,12 +33,10 @@
   var root = document.getElementById('sunplanner-app');
   if(!root){ console.warn('SunPlanner: brak #sunplanner-app'); return; }
 
-
   root.innerHTML =
   '<div class="sunplanner">'+
     '<div id="sp-toast" class="banner" style="display:none"></div>'+
     '<div class="row">'+
-
       '<input id="sp-place" class="input" placeholder="Dodaj punkt: start / przystanek / cel">'+
       '<button id="sp-add" class="btn" type="button">Dodaj</button>'+
       '<button id="sp-geo" class="btn secondary" type="button">Skąd jadę?</button>'+
@@ -60,16 +45,6 @@
     '</div>'+
     '<div class="toolbar">'+
       '<label class="switch"><input id="sp-radar" type="checkbox">Radar opadów</label>'+
-
-      '<input id="sp-place" class="input" placeholder="Dodaj punkt: Start / Przystanek / Cel">'+
-      '<button id="sp-add" class="btn" type="button">Dodaj</button>'+
-      '<button id="sp-geo" class="btn secondary" type="button">Skad jade?</button>'+
-      '<input id="sp-date" class="input" type="date" style="max-width:170px">'+
-      '<button id="sp-clear" class="btn secondary" type="button">Wyczysc</button>'+
-    '</div>'+
-    '<div class="toolbar">'+
-      '<label class="switch"><input id="sp-radar" type="checkbox">Radar opadow</label>'+
-
       '<div class="legend">'+
         '<span class="c1"><i></i>Najlepsza</span>'+
         '<span class="c2"><i></i>Alternatywa</span>'+
@@ -77,7 +52,6 @@
       '</div>'+
     '</div>'+
     '<div id="planner-map" aria-label="Mapa"></div>'+
-
     '<div class="card route-card">'+
       '<h3>Punkty trasy (start, przystanki, cel)</h3>'+
       '<div id="sp-list"></div>'+
@@ -95,8 +69,8 @@
         '<div class="golden-block">'+
           '<div class="glow-info">'+
             '<h4>Poranek</h4>'+
-            '<p id="sp-gold-am" class="glow-line">Złota — —</p>'+
-            '<p id="sp-blue-am" class="glow-line">Niebieska — —</p>'+
+            '<p id="sp-gold-am" class="glow-line">☀️ Poranna złota godzina: — —</p>'+
+            '<p id="sp-blue-am" class="glow-line">🌌 Poranna niebieska godzina: — —</p>'+
           '</div>'+
           '<div class="grid2">'+
             '<div class="card inner">'+
@@ -148,92 +122,17 @@
           '</div>'+
           '<div class="glow-info align-right">'+
             '<h4>Wieczór</h4>'+
-            '<p id="sp-gold-pm" class="glow-line">Złota — —</p>'+
-            '<p id="sp-blue-pm" class="glow-line">Niebieska — —</p>'+
+            '<p id="sp-gold-pm" class="glow-line">☀️ Wieczorna złota godzina: — —</p>'+
+            '<p id="sp-blue-pm" class="glow-line">🌌 Wieczorna niebieska godzina: — —</p>'+
           '</div>'+
         '</div>'+
 
         '<h3 style="margin-top:1rem">Udostępnij / Eksport</h3>'+
-
-    '<div class="cards">'+
-      '<div class="card">'+
-        '<h3>Plan dnia</h3>'+
-        '<div class="rowd"><span class="muted">Cel (ostatni punkt)</span><strong id="sp-loc">—</strong></div>'+
-        '<div class="rowd"><span class="muted">Data</span><strong id="sp-date-label">—</strong></div>'+
-        '<div class="rowd"><span>Czas jazdy</span><strong id="sp-t-time">—</strong></div>'+
-        '<div class="rowd"><span>Dystans</span><strong id="sp-t-dist">—</strong></div>'+
-
-        '<div class="grid2" style="margin-top:.75rem">'+
-          '<div class="card" style="padding:.75rem">'+
-            '<h3 style="margin-bottom:.25rem">Swit <small id="sp-rise-date" class="muted"></small></h3>'+
-            '<div class="rowd"><span>Swit</span><strong id="sp-rise-sun">—</strong></div>'+
-            '<div class="rowd"><span>Start</span><strong id="sp-rise-start">—</strong></div>'+
-            '<div class="rowd"><span>Wyjazd</span><strong id="sp-rise-wake">—</strong></div>'+
-            '<div class="rowd"><span>Sen od</span><strong id="sp-rise-bed">—</strong></div>'+
-            '<p class="muted" style="margin:.25rem 0 .4rem">Ile snu chcesz miec?</p>'+
-            '<div style="display:flex;align-items:center;gap:.7rem">'+
-              '<div class="ring">'+
-                '<svg width="56" height="56"><circle cx="28" cy="28" r="24" stroke="#e5e7eb" stroke-width="4" fill="none"></circle><circle id="sp-ring-rise" cx="28" cy="28" r="24" stroke="#e94244" stroke-width="4" fill="none" stroke-linecap="round"></circle></svg>'+
-                '<div class="text" id="sp-txt-rise">6 h</div>'+
-              '</div>'+
-              '<input id="sp-slider-rise" class="slider" type="range" min="1" max="8" step="1" value="6" style="flex:1">'+
-            '</div>'+
-            '<div class="badge" id="sp-gold-am">Zlota — —</div>'+
-            '<div class="badge" id="sp-blue-am">Niebieska — —</div>'+
-            '<div class="kpi">'+
-              '<div class="rowd"><span>Temp.</span><strong id="sp-rise-t">—</strong></div>'+
-              '<div class="rowd"><span>Wiatr</span><strong id="sp-rise-w">—</strong></div>'+
-              '<div class="rowd"><span>Chmury</span><strong id="sp-rise-c">—</strong></div>'+
-              '<div class="rowd"><span>Wilg.</span><strong id="sp-rise-h">—</strong></div>'+
-              '<div class="rowd"><span>Widzoc.</span><strong id="sp-rise-v">—</strong></div>'+
-              '<div class="rowd"><span>Opady</span><strong id="sp-rise-p">—</strong></div>'+
-            '</div>'+
-          '</div>'+
-          '<div class="card" style="padding:.75rem">'+
-            '<h3 style="margin-bottom:.25rem">Zachod <small id="sp-set-date" class="muted"></small></h3>'+
-            '<div class="rowd"><span>Zachod</span><strong id="sp-set-sun">—</strong></div>'+
-            '<div class="rowd"><span>Start</span><strong id="sp-set-start">—</strong></div>'+
-            '<div class="rowd"><span>Wyjazd</span><strong id="sp-set-wake">—</strong></div>'+
-            '<div class="rowd"><span>Przygot. do</span><strong id="sp-set-bed">—</strong></div>'+
-            '<p class="muted" style="margin:.25rem 0 .4rem">Ile potrzebujesz przygotowan?</p>'+
-            '<div style="display:flex;align-items:center;gap:.7rem">'+
-              '<div class="ring">'+
-                '<svg width="56" height="56"><circle cx="28" cy="28" r="24" stroke="#e5e7eb" stroke-width="4" fill="none"></circle><circle id="sp-ring-set" cx="28" cy="28" r="24" stroke="#e94244" stroke-width="4" fill="none" stroke-linecap="round"></circle></svg>'+
-                '<div class="text" id="sp-txt-set">6 h</div>'+
-              '</div>'+
-              '<input id="sp-slider-set" class="slider" type="range" min="1" max="8" step="1" value="6" style="flex:1">'+
-            '</div>'+
-            '<div class="badge" id="sp-gold-pm">Zlota — —</div>'+
-            '<div class="badge" id="sp-blue-pm">Niebieska — —</div>'+
-            '<div class="kpi">'+
-              '<div class="rowd"><span>Temp.</span><strong id="sp-set-t">—</strong></div>'+
-              '<div class="rowd"><span>Wiatr</span><strong id="sp-set-w">—</strong></div>'+
-              '<div class="rowd"><span>Chmury</span><strong id="sp-set-c">—</strong></div>'+
-              '<div class="rowd"><span>Wilg.</span><strong id="sp-set-h">—</strong></div>'+
-              '<div class="rowd"><span>Widzoc.</span><strong id="sp-set-v">—</strong></div>'+
-              '<div class="rowd"><span>Opady</span><strong id="sp-set-p">—</strong></div>'+
-            '</div>'+
-          '</div>'+
-        '</div>'+
-
-        '<h3 style="margin-top:1rem">Punkty trasy (start, przystanki, cel)</h3>'+
-        '<div id="sp-list"></div>'+
-        '<div class="row" style="margin-top:.4rem"><button id="sp-opt" class="btn secondary" type="button">Optymalizuj</button></div>'+
-
-        '<h3 style="margin-top:1rem">Alternatywne trasy</h3>'+
-        '<div id="sp-route-choices" class="route-options"></div>'+
-
-        '<h3 style="margin-top:1rem">Udostepnij / Eksport</h3>'+
-
         '<div class="row share-row" style="align-items:flex-start">'+
           '<div class="col" style="flex:1">'+
             '<div class="row" style="gap:.35rem;flex-wrap:wrap">'+
               '<button id="sp-copy" class="btn secondary" type="button">Kopiuj link</button>'+
-
               '<button id="sp-short" class="btn secondary" type="button">Krótki link</button>'+
-
-              '<button id="sp-short" class="btn secondary" type="button">Krotki link</button>'+
-
               '<button id="sp-ics" class="btn secondary" type="button">Eksport do kalendarza</button>'+
               '<button id="sp-client-card" class="btn secondary" type="button">Karta klienta</button>'+
               '<button id="sp-print" class="btn secondary" type="button">Drukuj / PDF</button>'+
@@ -249,21 +148,12 @@
         '</div>'+
       '</div>'+
       '<div class="card">'+
-
         '<h3>Wykres ścieżki słońca</h3>'+
         '<div class="sun-meta">'+
           '<div><span class="muted">Świt</span><strong id="sp-sunrise-time">—</strong><small id="sp-sunrise-az">—</small></div>'+
           '<div><span class="muted">Zachód</span><strong id="sp-sunset-time">—</strong><small id="sp-sunset-az">—</small></div>'+
         '</div>'+
         '<canvas id="sp-sun-canvas" class="smallcanvas" aria-label="Wykres słońca"></canvas>'+
-
-        '<h3>Wykres sciezki slonca</h3>'+
-        '<div class="sun-meta">'+
-          '<div><span class="muted">Swit</span><strong id="sp-sunrise-time">—</strong><small id="sp-sunrise-az">—</small></div>'+
-          '<div><span class="muted">Zachod</span><strong id="sp-sunset-time">—</strong><small id="sp-sunset-az">—</small></div>'+
-        '</div>'+
-        '<canvas id="sp-sun-canvas" class="smallcanvas" aria-label="Wykres slonca"></canvas>'+
-
       '</div>'+
       '<div class="card">'+
         '<h3>Mini-wykres godzinowy</h3>'+
@@ -272,12 +162,7 @@
     '</div>'+
   '</div>';
 
-
   // helpers
-
-
-  // helpers (bez unicode w komunikatach)
-
   function $(s){ return document.querySelector(s); }
   function toast(m,type){ var t=$("#sp-toast"); t.textContent=m; t.style.display='block'; t.style.background=(type==='ok'?'#dcfce7':'#fee2e2'); t.style.color=(type==='ok'?'#14532d':'#991b1b'); clearTimeout(toast._t); toast._t=setTimeout(function(){t.style.display='none';}, 4200); }
   function fmt(d){ return d instanceof Date && !isNaN(d) ? d.toLocaleTimeString('pl-PL',{hour:'2-digit',minute:'2-digit'}) : '—'; }
@@ -296,12 +181,7 @@
     return {lat:lat2*180/Math.PI,lng:lng2*180/Math.PI};
   }
 
-
   // stan
-
-
-  // stan
-
   var map, geocoder, dirService, placesAutocomplete, dragMarker;
   var dirRenderers = [];
   var points = [];
@@ -312,18 +192,14 @@
   var forecastCache = {};
   var shortLinkValue = null;
   var lastSunData = {rise:null,set:null,lat:null,lng:null,label:'',date:null};
-
   var radarLayer = null, radarTemplate = null, radarFetchedAt = 0;
-
-  var radarLayer = null;
-
+  var RADAR_FALLBACK_TEMPLATE = 'https://tilecache.rainviewer.com/v2/radar/nowcast_0/256/{z}/{x}/{y}/2/1_1.png';
   var restoredFromShare = false;
   var STORAGE_KEY = 'sunplanner-state';
   var storageAvailable = (function(){ try{return !!window.localStorage; }catch(e){ return false; } })();
   var routeColors = ['#e94244','#1e3a8a','#6b7280'];
   var pendingRadar = false;
 
-
   // data
   var today=new Date(), max=new Date(today); max.setDate(max.getDate()+16);
   var dEl = $('#sp-date');
@@ -346,31 +222,6 @@
       return JSON.parse(json);
     }
   };
-
-
-  // data
-  var today=new Date(), max=new Date(today); max.setDate(max.getDate()+16);
-  var dEl = $('#sp-date');
-  dEl.min=today.toISOString().split('T')[0]; dEl.max=max.toISOString().split('T')[0];
-  dEl.value = dEl.value || today.toISOString().split('T')[0];
-
-  function dateFromInput(iso){ var a=(iso||'').split('-'); return new Date(Date.UTC(+a[0],(+a[1]||1)-1,+a[2]||1,12,0,0)); }
-
-  // link persist
-  var b64url = {
-    enc: function(obj){
-      var json = JSON.stringify(obj);
-      var utf8 = unescape(encodeURIComponent(json));
-      var b = btoa(utf8).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
-      return b;
-    },
-    dec: function(s){
-      s = (s||'').replace(/-/g,'+').replace(/_/g,'/'); while(s.length%4)s+='=';
-      var json = decodeURIComponent(escape(atob(s)));
-      return JSON.parse(json);
-    }
-  };
-
   function packState(){
     var radarEl=$('#sp-radar');
     return {
@@ -398,11 +249,9 @@
     if(sp){
       try{ unpackState(b64url.dec(sp)); restoredFromShare=true; }
       catch(e){ console.warn('SP decode',e); }
-
     } else if(CFG.SHARED_SP){
       try{ unpackState(b64url.dec(CFG.SHARED_SP)); restoredFromShare=true; }
       catch(err){ console.warn('Share decode',err); }
-
     } else if(storageAvailable){
       try{
         var saved=window.localStorage.getItem(STORAGE_KEY);
@@ -411,7 +260,6 @@
     }
   })();
 
-
   // SunCalc lite (fallback)
   var SunCalcLite=(function(){
     var PI=Math.PI, R=PI/180, DAY=86400000;
@@ -419,16 +267,6 @@
     function M(d){ return R*(357.5291+0.98560028*d); }
     function L(m){ var C=R*(1.9148*Math.sin(m)+.02*Math.sin(2*m)+.0003*Math.sin(3*m)); return m+C+102.9372*R+PI; }
     function dec(Ls){ return Math.asin(Math.sin(Ls)*Math.sin(e)); }
-
-
-  // SunCalc lite (fallback)
-  var SunCalcLite=(function(){
-    var PI=Math.PI, R=PI/180, DAY=86400000;
-    var e=23.4397*R;
-    function M(d){ return R*(357.5291+0.98560028*d); }
-    function L(m){ var C=R*(1.9148*Math.sin(m)+.02*Math.sin(2*m)+.0003*Math.sin(3*m)); return m+C+102.9372*R+PI; }
-    function dec(Ls){ return Math.asin(Math.sin(Ls)*Math.sin(e)); }
-
     function H(h,phi,dc){ var v=(Math.sin(h)-Math.sin(phi)*Math.sin(dc))/(Math.cos(phi)*Math.cos(dc)); if(v<-1)v=-1; if(v>1)v=1; return Math.acos(v); }
     function cyc(d,lw){ return Math.round(d-0.0009-lw/(2*Math.PI)); }
     function approx(Ht,lw,n){ return 0.0009+(Ht+lw)/(2*Math.PI)+n; }
@@ -439,11 +277,7 @@
     function sidereal(d,lw){ return R*(280.16+360.9856235*d)-lw; }
     function alt(Ht,phi,dc){ return Math.asin(Math.sin(phi)*Math.sin(dc)+Math.cos(phi)*Math.cos(dc)*Math.cos(Ht)); }
     function az(Ht,phi,dc){ return Math.atan2(Math.sin(Ht), Math.cos(Ht)*Math.sin(phi)-Math.tan(dc)*Math.cos(phi)); }
-
     var HZ={sunrise:-0.833*R, civil:-6*R, goldUp:6*R};
-
-    var HZ={sunrise:-0.833*R, civil:-6*R, goldUp:6*R};
-
     function getTimes(date,lat,lng){
       var lw=-lng*R, phi=lat*R, d=toJ(date)-2451545, n=cyc(d,lw), ds=approx(0,lw,n);
       var m=M(ds), l=L(m), dc=dec(l);
@@ -465,7 +299,6 @@
   })();
   var SunCalc = (window.SunCalc && window.SunCalc.getTimes && window.SunCalc.getPosition) ? window.SunCalc : SunCalcLite;
 
-
   function bands(lat,lng,date){
     var t=SunCalc.getTimes(date,lat,lng);
     function pair(a,b){ return a<=b?[a,b]:[b,a]; }
@@ -478,41 +311,17 @@
   }
 
   // lista
-
-
-  function bands(lat,lng,date){
-    var t=SunCalc.getTimes(date,lat,lng);
-    function pair(a,b){ return a<=b?[a,b]:[b,a]; }
-    return {
-      goldAM: pair(t.sunrise,    t.goldenHourEnd),
-      goldPM: pair(t.goldenHour, t.sunset),
-      blueAM: pair(t.civilDawn,  t.sunrise),
-      bluePM: pair(t.sunset,     t.civilDusk)
-    };
-  }
-
-  // lista
-
   function renderList(){
     var box=$('#sp-list'); box.innerHTML='';
     points.forEach(function(p,i){
       var row=document.createElement('div'); row.className='waypoint';
       var lab=document.createElement('div'); lab.textContent=(i+1)+'. '+(p.label||'Punkt');
-
       var ctr=document.createElement('div');
       function mk(txt,fn){ var b=document.createElement('button'); b.className='btn ghost'; b.textContent=txt; b.onclick=fn; return b; }
       ctr.appendChild(mk('↑',function(){ if(i>0){ var tmp=points[i-1]; points[i-1]=points[i]; points[i]=tmp; renderList(); recalcRoute(false); updateDerived(); } }));
       ctr.appendChild(mk('↓',function(){ if(i<points.length-1){ var tmp=points[i+1]; points[i+1]=points[i]; points[i]=tmp; renderList(); recalcRoute(false); updateDerived(); } }));
       ctr.appendChild(mk('×',function(){ points.splice(i,1); renderList(); recalcRoute(false); updateDerived(); }));
       row.appendChild(lab); row.appendChild(ctr); box.appendChild(row);
-
-      var ctr=document.createElement('div');
-      function mk(txt,fn){ var b=document.createElement('button'); b.className='btn ghost'; b.textContent=txt; b.onclick=fn; return b; }
-      ctr.appendChild(mk('↑',function(){ if(i>0){ var tmp=points[i-1]; points[i-1]=points[i]; points[i]=tmp; renderList(); recalcRoute(false); updateDerived(); } }));
-      ctr.appendChild(mk('↓',function(){ if(i<points.length-1){ var tmp=points[i+1]; points[i+1]=points[i]; points[i]=tmp; renderList(); recalcRoute(false); updateDerived(); } }));
-      ctr.appendChild(mk('×',function(){ points.splice(i,1); renderList(); recalcRoute(false); updateDerived(); }));
-      row.appendChild(lab); row.appendChild(ctr); box.appendChild(row);
-
     });
   }
   function routeMetrics(route){
@@ -531,11 +340,7 @@
     box.innerHTML='';
     if(!currentRoutes.length){
       var msg=document.createElement('div'); msg.className='muted';
-
       msg.textContent='Dodaj co najmniej dwa punkty, aby zobaczyć trasy.';
-
-      msg.textContent='Dodaj co najmniej dwa punkty, aby zobaczyc trasy.';
-
       box.appendChild(msg);
       return;
     }
@@ -590,7 +395,6 @@
     setText('sp-loc', dest ? (dest.label || (dest.lat.toFixed(4)+','+dest.lng.toFixed(4))) : '—');
     setText('sp-date-label', dEl.value || '—');
     updateLink();
-
   }
 
   // geocode
@@ -616,33 +420,6 @@
   }
 
   // trasy
-
-  }
-
-  // geocode
-  var placesService;
-  function geocode(text){
-    return new Promise(function(resolve,reject){
-      if(!geocoder || !map){ reject(new Error('mapa niegotowa')); return; }
-      geocoder.geocode({address:text},function(res,st){
-        if(st==='OK' && res[0]){
-          var loc=res[0].geometry.location;
-          resolve({lat:loc.lat(),lng:loc.lng(),label:res[0].formatted_address});
-        } else {
-          if(!placesService) placesService = new google.maps.places.PlacesService(map);
-          placesService.textSearch({query:text},function(r2,st2){
-            if(st2==='OK' && r2[0]){
-              var loc=r2[0].geometry.location;
-              resolve({lat:loc.lat(),lng:loc.lng(),label:r2[0].name});
-            } else reject(new Error('Nie znaleziono'));
-          });
-        }
-      });
-    });
-  }
-
-  // trasy
-
   function clearRenderers(){ dirRenderers.forEach(function(r){ if(r && r.setMap) r.setMap(null); }); dirRenderers=[]; }
   function recalcRoute(optimize){
     setText('sp-t-dist','—'); setText('sp-t-time','—');
@@ -653,7 +430,6 @@
     var origin = new google.maps.LatLng(points[0].lat, points[0].lng);
     var destination = new google.maps.LatLng(points[points.length-1].lat, points[points.length-1].lng);
     var hasWps = points.length>2;
-
     var wps = hasWps ? points.slice(1,-1).map(function(p){ return {location:new google.maps.LatLng(p.lat,p.lng),stopover:true}; }) : [];
 
     var baseReq = {origin:origin, destination:destination, waypoints:wps, optimizeWaypoints: (!!optimize && hasWps), travelMode: google.maps.TravelMode.DRIVING};
@@ -670,24 +446,6 @@
     Promise.all(tasks).then(function(results){
       var valid = results.filter(function(x){return !!x;});
       if(!valid.length){ toast('Trasa niedostępna'); driveMin=0; currentRoutes=[]; renderRouteOptions(); updateSunWeather(); return; }
-
-    var wps = hasWps ? points.slice(1,-1).map(function(p){ return {location:new google.maps.LatLng(p.lat,p.lng),stopover:true}; }) : [];
-
-    var baseReq = {origin:origin, destination:destination, waypoints:wps, optimizeWaypoints: (!!optimize && hasWps), travelMode: google.maps.TravelMode.DRIVING};
-
-    var tasks=[];
-    if(!hasWps){
-      tasks.push(new Promise(function(res){ dirService.route(Object.assign({},baseReq,{provideRouteAlternatives:true}),function(r,s){ res(s==='OK'?r:null); }); }));
-    } else {
-      tasks.push(new Promise(function(res){ dirService.route(baseReq,function(r,s){ res(s==='OK'?r:null); }); }));
-      tasks.push(new Promise(function(res){ dirService.route(Object.assign({},baseReq,{avoidTolls:true}),function(r,s){ res(s==='OK'?r:null); }); }));
-      tasks.push(new Promise(function(res){ dirService.route(Object.assign({},baseReq,{avoidHighways:true}),function(r,s){ res(s==='OK'?r:null); }); }));
-    }
-
-    Promise.all(tasks).then(function(results){
-      var valid = results.filter(function(x){return !!x;});
-      if(!valid.length){ toast('Trasa niedostepna'); driveMin=0; currentRoutes=[]; renderRouteOptions(); updateSunWeather(); return; }
-
       var routes=[];
       if(!hasWps){
         routes = (valid[0] && valid[0].routes) ? valid[0].routes.slice(0,3) : [];
@@ -714,16 +472,11 @@
         });
       }
 
-
       if(!currentRoutes.length){ toast('Trasa niedostępna'); driveMin=0; renderRouteOptions(); updateSunWeather(); return; }
-
-      if(!currentRoutes.length){ toast('Trasa niedostepna'); driveMin=0; renderRouteOptions(); updateSunWeather(); return; }
-
       activeRouteIndex=0;
       setActiveRoute(0,true);
       refreshRendererStyles();
       updateSunWeather();
-
     }).catch(function(){ toast('Trasa niedostępna'); driveMin=0; currentRoutes=[]; renderRouteOptions(); updateSunWeather(); });
   }
 
@@ -750,33 +503,6 @@
     setText('sp-'+pref+'-wake', fmt(wake));
     setText('sp-'+pref+'-bed', fmt(bed));
   }
-    }).catch(function(){ toast('Trasa niedostepna'); driveMin=0; currentRoutes=[]; renderRouteOptions(); updateSunWeather(); });
-  }
-
-  // pogoda + slonce
-  var RISE_OFF=90, SET_OFF=120;
-  function parseLocalISO(iso){ if(!iso) return null; var sp=iso.split('T'); var d=sp[0].split('-'); var t=(sp[1]||'00:00').slice(0,5).split(':'); return new Date(+d[0],+d[1]-1,+d[2],+t[0]||0,+t[1]||0,0,0); }
-  function closestHourIndex(hourly,when){
-    if(!hourly || !hourly.time || !hourly.time.length || !(when instanceof Date)) return -1;
-    var best=0,b=1e15;
-    for(var i=0;i<hourly.time.length;i++){
-      var dt=parseLocalISO(hourly.time[i]); if(!dt) continue;
-      var diff=Math.abs(dt-when); if(diff<b){b=diff;best=i;}
-    }
-    return best;
-  }
-  function fillCardTimes(pref, sun, offMin, hours){
-    if(!(sun instanceof Date) || isNaN(sun)){ ['sun','start','wake','bed'].forEach(function(k){ setText('sp-'+pref+'-'+k,'—'); }); return; }
-    var start=new Date(sun - offMin*60000);
-    var depart=new Date(start - (driveMin||0)*60000);
-    var wake=new Date(depart - 30*60000);
-    var bed =new Date(wake - hours*3600000);
-    setText('sp-'+pref+'-sun', fmt(sun));
-    setText('sp-'+pref+'-start', fmt(start));
-    setText('sp-'+pref+'-wake', fmt(wake));
-    setText('sp-'+pref+'-bed', fmt(bed));
-  }
-
   function setWeatherOnly(pref, hourly, when){
     if(!hourly || !hourly.time || !hourly.time.length || !(when instanceof Date)) return;
     var idx=closestHourIndex(hourly, when);
@@ -816,11 +542,7 @@
     if(typeof lat!=='number' || typeof lng!=='number' || !(date instanceof Date)){
       ctx.fillStyle='#9ca3af';
       ctx.font='12px system-ui, sans-serif';
-
       ctx.fillText('Dodaj cel, aby zobaczyć wykres.',12,height/2);
-
-      ctx.fillText('Dodaj cel, aby zobaczyc wykres.',12,height/2);
-
       return;
     }
     var start=new Date(date); start.setHours(0,0,0,0);
@@ -878,13 +600,8 @@
       var tx=x+8; if(tx>width-70) tx=x-70; if(tx<0) tx=2;
       ctx.fillText(txt, tx, y-6);
     }
-
     mark(sunrise,'Świt','#f59e0b');
     mark(sunset,'Zachód','#f97316');
-
-    mark(sunrise,'Swit','#f59e0b');
-    mark(sunset,'Zachod','#f97316');
-
 
     ctx.fillStyle='#6b7280';
     for(var h=0;h<=24;h+=3){
@@ -904,11 +621,7 @@
     ctx.fillRect(0,0,width,height);
     ctx.font='12px system-ui, sans-serif';
     ctx.fillStyle='#9ca3af';
-
     if(loading){ ctx.fillText('Ładowanie prognozy...',12,height/2); return; }
-
-    if(loading){ ctx.fillText('Ladowanie prognozy...',12,height/2); return; }
-
     if(!hourly || !hourly.time || !hourly.time.length){ ctx.fillText('Brak danych pogodowych.',12,height/2); return; }
     var points=[];
     for(var i=0;i<hourly.time.length;i++){
@@ -1021,7 +734,6 @@
     return entry.promise;
   }
 
-
   function updateSunWeather(){
     var dest=points[points.length-1], dStr=dEl.value;
     setText('sp-rise-date', dStr||''); setText('sp-set-date', dStr||'');
@@ -1037,17 +749,10 @@
     var base=dateFromInput(dStr);
     var b=bands(dest.lat, dest.lng, base);
     function rng(a,b){ return fmt(a)+'–'+fmt(b); }
-
-    setText('sp-gold-am','Złota '+rng(b.goldAM[0],b.goldAM[1]));
-    setText('sp-blue-am','Niebieska '+rng(b.blueAM[0],b.blueAM[1]));
-    setText('sp-gold-pm','Złota '+rng(b.goldPM[0],b.goldPM[1]));
-    setText('sp-blue-pm','Niebieska '+rng(b.bluePM[0],b.bluePM[1]));
-
-    setText('sp-gold-am','Zlota '+rng(b.bluePM[0],b.bluePM[1]));
-    setText('sp-blue-am','Niebieska '+rng(b.goldPM[0],b.goldPM[1]));
-    setText('sp-gold-pm','Zlota '+rng(b.blueAM[0],b.blueAM[1]));
-    setText('sp-blue-pm','Niebieska '+rng(b.goldAM[0],b.goldAM[1]));
-
+    setText('sp-gold-am','☀️ Poranna złota godzina: '+rng(b.goldAM[0],b.goldAM[1]));
+    setText('sp-blue-am','🌌 Poranna niebieska godzina: '+rng(b.blueAM[0],b.blueAM[1]));
+    setText('sp-gold-pm','☀️ Wieczorna złota godzina: '+rng(b.goldPM[0],b.goldPM[1]));
+    setText('sp-blue-pm','🌌 Wieczorna niebieska godzina: '+rng(b.bluePM[0],b.bluePM[1]));
 
     var t=SunCalc.getTimes(base, dest.lat, dest.lng);
     var sunrise=t.sunrise, sunset=t.sunset;
@@ -1083,7 +788,6 @@
       .catch(function(){ renderHourlyChart(null,dStr,false); });
   }
 
-
   function fetchRadarTemplate(){
     return fetch('https://api.rainviewer.com/public/weather-maps.json')
       .then(function(r){ if(!r.ok) throw new Error('http'); return r.json(); })
@@ -1091,7 +795,21 @@
         var frames = (data && data.radar && data.radar.nowcast) ? data.radar.nowcast : [];
         if(!frames.length) throw new Error('no-data');
         var latest = frames[frames.length-1];
-        radarTemplate = 'https://tilecache.rainviewer.com/v2/radar/'+latest.time+'/256/{z}/{x}/{y}/2/1_1.png';
+        var template = null;
+        if(latest){
+          if(latest.path){
+            template = 'https://tilecache.rainviewer.com/v2/radar/'+latest.path+'256/{z}/{x}/{y}/2/1_1.png';
+          } else if(typeof latest.time !== 'undefined'){
+            template = 'https://tilecache.rainviewer.com/v2/radar/'+latest.time+'/256/{z}/{x}/{y}/2/1_1.png';
+          }
+        }
+        if(!template) throw new Error('no-template');
+        radarTemplate = template;
+        radarFetchedAt = Date.now();
+      })
+      .catch(function(err){
+        console.warn('SunPlanner radar template fallback', err);
+        radarTemplate = RADAR_FALLBACK_TEMPLATE;
         radarFetchedAt = Date.now();
       });
   }
@@ -1133,25 +851,6 @@
         toast('Radar chwilowo niedostępny');
         updateLink();
       });
-
-  function toggleRadar(enabled){
-    if(!map) return;
-    var overlays=map.overlayMapTypes;
-    if(enabled){
-      if(!radarLayer){
-        radarLayer=new google.maps.ImageMapType({
-          getTileUrl:function(coord,zoom){
-            return 'https://tilecache.rainviewer.com/v2/radar/nowcast_0/256/'+zoom+'/'+coord.x+'/'+coord.y+'/2/1_1.png';
-          },
-          tileSize:new google.maps.Size(256,256),
-          opacity:0.6,
-          name:'Radar opadow'
-        });
-      }
-      var exists=false;
-      for(var i=0;i<overlays.getLength();i++){ if(overlays.getAt(i)===radarLayer){ exists=true; break; } }
-      if(!exists) overlays.insertAt(0,radarLayer);
-
     } else {
       for(var j=overlays.getLength()-1;j>=0;j--){ if(overlays.getAt(j)===radarLayer){ overlays.removeAt(j); } }
     }
@@ -1168,17 +867,12 @@
     if(box){
       box.innerHTML='';
       if(url){
-
         var span=document.createElement('span'); span.textContent='Krótki link: ';
-
-        var span=document.createElement('span'); span.textContent='Krotki link: ';
-
         var a=document.createElement('a'); a.href=url; a.target='_blank'; a.rel='noopener'; a.textContent=url;
         box.appendChild(span); box.appendChild(a);
       }
     }
     if(url){
-
       try{ navigator.clipboard.writeText(url); toast('Krótki link skopiowany','ok'); }
       catch(e){ toast('Krótki link gotowy','ok'); }
     }
@@ -1190,30 +884,13 @@
       .then(function(r){ if(!r.ok) throw new Error('http'); return r.json(); })
       .then(function(data){ if(data && data.url){ setShortLink(data.url); } else { if(box) box.textContent='Nie udało się wygenerować linku.'; } })
       .catch(function(){ if(box) box.textContent='Nie udało się wygenerować linku.'; });
-
-      try{ navigator.clipboard.writeText(url); toast('Krotki link skopiowany','ok'); }
-      catch(e){ toast('Krotki link gotowy','ok'); }
-    }
-  }
-  function createShortLink(){
-    if(!REST_URL){ toast('Funkcja skroconego linku niedostepna'); return; }
-    var box=$('#sp-short-status'); if(box){ box.textContent='Generuje link...'; }
-    fetch(REST_URL,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({sp:b64url.enc(packState())})})
-      .then(function(r){ if(!r.ok) throw new Error('http'); return r.json(); })
-      .then(function(data){ if(data && data.url){ setShortLink(data.url); } else { if(box) box.textContent='Nie udalo sie wygenerowac linku.'; } })
-      .catch(function(){ if(box) box.textContent='Nie udalo sie wygenerowac linku.'; });
-
   }
   function formatICS(date){
     if(!(date instanceof Date) || isNaN(date)) return null;
     return date.toISOString().replace(/[-:]/g,'').replace(/\.\d{3}/,'')+'Z';
   }
   function exportCalendar(){
-
     if(!lastSunData || !lastSunData.rise || !lastSunData.set || !lastSunData.date){ toast('Uzupełnij plan trasy.'); return; }
-
-    if(!lastSunData || !lastSunData.rise || !lastSunData.set || !lastSunData.date){ toast('Uzupelnij plan trasy.'); return; }
-
     var riseICS=formatICS(lastSunData.rise);
     var setICS=formatICS(lastSunData.set);
     if(!riseICS || !setICS){ toast('Brak danych do eksportu.'); return; }
@@ -1226,26 +903,16 @@
       'DTSTAMP:'+formatICS(new Date()),
       'DTSTART:'+riseICS,
       'DTEND:'+formatICS(new Date(lastSunData.rise.getTime()+3600000)),
-
       'SUMMARY:Świt - '+destLabel,
       'LOCATION:'+(destLabel.replace(/\r?\n/g,' ')),
       'DESCRIPTION:Plan świtu dla '+destLabel,
-
-      'SUMMARY:Swit - '+destLabel,
-      'LOCATION:'+(destLabel.replace(/\r?\n/g,' ')),
-      'DESCRIPTION:Plan switu dla '+destLabel,
-
       'END:VEVENT',
       'BEGIN:VEVENT',
       'UID:'+uidBase+'-set@sunplanner',
       'DTSTAMP:'+formatICS(new Date()),
       'DTSTART:'+setICS,
       'DTEND:'+formatICS(new Date(lastSunData.set.getTime()+3600000)),
-
       'SUMMARY:Zachód - '+destLabel,
-
-      'SUMMARY:Zachod - '+destLabel,
-
       'LOCATION:'+(destLabel.replace(/\r?\n/g,' ')),
       'DESCRIPTION:Plan zachodu dla '+destLabel,
       'END:VEVENT',
@@ -1261,11 +928,7 @@
     if(!dest){ toast('Dodaj cel trasy.'); return; }
     var metrics=activeRouteMetrics();
     var w=window.open('', '_blank');
-
     if(!w){ toast('Odblokuj wyskakujące okna.'); return; }
-
-    if(!w){ toast('Odblokuj wyskakujace okna.'); return; }
-
     var esc=function(str){
       return String(str||'').replace(/[&<>"']/g,function(ch){
         switch(ch){
@@ -1285,7 +948,6 @@
     var min=metrics ? Math.round(metrics.durationSec/60) : 0;
     var h=Math.floor(min/60), m=min%60;
     var timeTxt = metrics ? ((h? h+' h ':'')+m+' min') : '—';
-
     var sunCanvas=document.getElementById('sp-sun-canvas');
     var hourlyCanvas=document.getElementById('sp-hourly');
     var sunImage='', hourlyImage='';
@@ -1295,19 +957,13 @@
       if(src){ return '<div class="chart-card"><h3>'+title+'</h3><img src="'+esc(src)+'" alt="'+esc(alt)+'"></div>'; }
       return '<div class="chart-card"><h3>'+title+'</h3><p class="muted">'+esc(empty)+'</p></div>';
     }
-    var chartsHtml = chartBlock('Ścieżka słońca', sunImage, 'Wykres ścieżki słońca', 'Brak danych wykresu.')+
+    var chartsHtml = chartBlock('Wykres ścieżki słońca', sunImage, 'Wykres ścieżki słońca', 'Brak danych wykresu.')+
       chartBlock('Mini-wykres godzinowy', hourlyImage, 'Mini-wykres godzinowy', 'Brak danych wykresu.');
     var html='<!DOCTYPE html><html lang="pl"><head><meta charset="utf-8"><title>Karta klienta</title><style>body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;color:#111;padding:24px;}h1{margin:0 0 12px;font-size:24px;}section{margin-bottom:20px;}table{width:100%;border-collapse:collapse;margin-top:12px;}td,th{border:1px solid #e5e7eb;padding:8px;text-align:left;}ul{padding-left:18px;}small{color:#6b7280;}.muted{color:#6b7280;}.chart-grid{display:flex;gap:20px;flex-wrap:wrap;margin-top:12px;}.chart-card{flex:1 1 280px;background:#f9fafb;border:1px solid #e5e7eb;border-radius:16px;padding:16px;box-shadow:0 8px 18px rgba(15,23,42,0.08);} .chart-card h3{margin:0 0 12px;font-size:18px;} .chart-card img{width:100%;display:block;border-radius:12px;border:1px solid #d1d5db;background:#fff;} .chart-card p{margin:8px 0 0;color:#6b7280;}</style></head><body>'+
       '<h1>Karta klienta – '+esc(dest.label||'Plan pleneru')+'</h1>'+
       '<section><strong>Data:</strong> '+esc(dEl.value||'—')+'<br><strong>Cel:</strong> '+esc(dest.label||'—')+'<br><strong>Dystans:</strong> '+esc(distTxt)+'<br><strong>Czas przejazdu:</strong> '+esc(timeTxt)+'</section>'+
       '<section><table><tr><th>Moment</th><th>Godzina</th><th>Azymut</th></tr><tr><td>Świt</td><td>'+esc(riseText)+'</td><td>'+(lastSunData.riseAz!=null?esc(lastSunData.riseAz+'°'):'—')+'</td></tr><tr><td>Zachód</td><td>'+esc(setTextVal)+'</td><td>'+(lastSunData.setAz!=null?esc(lastSunData.setAz+'°'):'—')+'</td></tr></table></section>'+
       '<section><h2>Wizualizacje</h2><div class="chart-grid">'+chartsHtml+'</div></section>'+
-
-    var html='<!DOCTYPE html><html lang="pl"><head><meta charset="utf-8"><title>Karta klienta</title><style>body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;color:#111;padding:24px;}h1{margin:0 0 12px;font-size:24px;}section{margin-bottom:20px;}table{width:100%;border-collapse:collapse;margin-top:12px;}td,th{border:1px solid #e5e7eb;padding:8px;text-align:left;}ul{padding-left:18px;}small{color:#6b7280;}</style></head><body>'+
-      '<h1>Karta klienta – '+esc(dest.label||'Plan pleneru')+'</h1>'+
-      '<section><strong>Data:</strong> '+esc(dEl.value||'—')+'<br><strong>Cel:</strong> '+esc(dest.label||'—')+'<br><strong>Dystans:</strong> '+esc(distTxt)+'<br><strong>Czas przejazdu:</strong> '+esc(timeTxt)+'</section>'+
-      '<section><table><tr><th>Moment</th><th>Godzina</th><th>Azymut</th></tr><tr><td>Swit</td><td>'+esc(riseText)+'</td><td>'+(lastSunData.riseAz!=null?esc(lastSunData.riseAz+'°'):'—')+'</td></tr><tr><td>Zachod</td><td>'+esc(setTextVal)+'</td><td>'+(lastSunData.setAz!=null?esc(lastSunData.setAz+'°'):'—')+'</td></tr></table></section>'+
-
       '<section><h2>Punkty trasy</h2><ul>'+pointsHtml+'</ul></section>'+
       '<section><h2>Uwagi</h2><p>Notatki klienta:</p><div style="min-height:80px;border:1px solid #e5e7eb;border-radius:8px;"></div></section>'+
       '<small>Wygenerowano przez SunPlanner.</small>'+
@@ -1317,11 +973,7 @@
     setTimeout(function(){ try{w.focus(); w.print();}catch(e){} }, 400);
   }
   function locateStart(){
-
     if(!navigator.geolocation){ toast('Brak wsparcia geolokalizacji w przeglądarce'); return; }
-
-    if(!navigator.geolocation){ toast('Brak wsparcia geolokalizacji w przegladarce'); return; }
-
     navigator.geolocation.getCurrentPosition(function(pos){
       var lat=pos.coords.latitude, lng=pos.coords.longitude;
       function apply(label){
@@ -1336,7 +988,6 @@
           if(st==='OK' && res && res[0]) apply(res[0].formatted_address); else apply('Moja lokalizacja');
         });
       } else apply('Moja lokalizacja');
-
     }, function(){ toast('Nie udało się pobrać lokalizacji'); }, {enableHighAccuracy:true,timeout:8000});
   }
 
@@ -1414,85 +1065,6 @@
       renderList(); recalcRoute(false); updateDerived(); loadGallery();
     });
 
-
-    }, function(){ toast('Nie udalo sie pobrac lokalizacji'); }, {enableHighAccuracy:true,timeout:8000});
-  }
-
-  // galeria (tylko cel, 6 zdjec, link w nowym oknie)
-  function loadGallery(){
-    var dest=points[points.length-1]; var label=dest? (dest.label||'') : ''; var gal=$('#sp-gallery');
-    if(!label){ gal.innerHTML=''; return; }
-    gal.innerHTML='<div class="muted">Laduje zdjecia...</div>';
-
-    function renderItems(items, makeUrl, makeThumb){
-      gal.innerHTML='';
-      items.forEach(function(it){
-        var a=document.createElement('a'); a.href=makeUrl(it); a.target='_blank'; a.rel='noopener';
-        var img=new Image(); img.src=makeThumb(it); img.loading='lazy'; img.alt=label+' - inspiracja';
-        a.appendChild(img); gal.appendChild(a);
-      });
-      if(!gal.children.length) gal.innerHTML='<div class="muted">Brak zdjec.</div>';
-    }
-
-    if(CSE_ID){
-      fetch('https://www.googleapis.com/customsearch/v1?key='+GMAPS_KEY+'&cx='+CSE_ID+'&searchType=image&num=6&q='+encodeURIComponent(label+' sesja slubna'))
-        .then(function(r){ return r.json(); })
-        .then(function(data){
-          if(data && data.items && data.items.length){
-            renderItems(data.items.slice(0,6), function(it){ return it.link; }, function(it){ return (it.image && it.image.thumbnailLink)? it.image.thumbnailLink : it.link; });
-          } else {
-            // fallback Unsplash
-            fetch('https://api.unsplash.com/search/photos?per_page=6&query='+encodeURIComponent(label+' wedding shoot')+'&client_id='+UNSPLASH_KEY)
-              .then(function(r){ return r.json(); })
-              .then(function(d){
-                var arr=(d && d.results)? d.results : [];
-                renderItems(arr, function(p){ return (p.links && p.links.html) ? p.links.html : (p.urls && p.urls.regular ? p.urls.regular : '#'); }, function(p){ return p.urls.small; });
-              })
-              .catch(function(){ gal.innerHTML='<div class="muted">Blad galerii.</div>'; });
-          }
-        })
-        .catch(function(){ gal.innerHTML='<div class="muted">Blad galerii.</div>'; });
-    } else {
-      fetch('https://api.unsplash.com/search/photos?per_page=6&query='+encodeURIComponent(label+' wedding shoot')+'&client_id='+UNSPLASH_KEY)
-        .then(function(r){ return r.json(); })
-        .then(function(d){
-          var arr=(d && d.results)? d.results : [];
-          renderItems(arr, function(p){ return (p.links && p.links.html) ? p.links.html : (p.urls && p.urls.regular ? p.urls.regular : '#'); }, function(p){ return p.urls.small; });
-        })
-        .catch(function(){ gal.innerHTML='<div class="muted">Blad galerii.</div>'; });
-    }
-  }
-
-  // mapa
-  function initMap(){
-    var mapEl=document.getElementById('planner-map');
-    if(mapEl.offsetHeight<50) mapEl.style.minHeight='420px';
-
-    var DEF={lat:49.2992,lng:19.9496};
-    map=new google.maps.Map(mapEl,{
-      center:DEF, zoom:11, disableDefaultUI:false,
-      gestureHandling:'greedy', zoomControl:true, mapTypeControl:false, streetViewControl:false
-    });
-
-    // blokada scrolla strony nad mapa (zoom zostaje)
-    mapEl.addEventListener('wheel', function(e){ e.preventDefault(); }, {passive:false});
-
-    geocoder=new google.maps.Geocoder();
-    dirService=new google.maps.DirectionsService();
-
-    dragMarker=new google.maps.Marker({position:DEF,map:map,draggable:true,visible:false});
-    google.maps.event.addListener(map,'click',function(e){ dragMarker.setPosition(e.latLng); dragMarker.setVisible(true); });
-
-    placesAutocomplete=new google.maps.places.Autocomplete($('#sp-place'),{fields:['geometry','name']});
-    placesAutocomplete.addListener('place_changed',function(){
-      var pl=placesAutocomplete.getPlace(); if(!pl || !pl.geometry) return;
-      var pos=pl.geometry.location;
-      points.push({lat:pos.lat(),lng:pos.lng(),label:pl.name||$('#sp-place').value||'Punkt'});
-      $('#sp-place').value='';
-      renderList(); recalcRoute(false); updateDerived(); loadGallery();
-    });
-
-
     renderList(); updateDerived(); renderRouteOptions();
     if(points.length>=2) recalcRoute(false); else updateSunWeather();
     loadGallery(); updateLink();
@@ -1501,7 +1073,6 @@
 
     google.maps.event.addListenerOnce(map,'idle',function(){ google.maps.event.trigger(map,'resize'); });
   }
-
 
   // UI
   $('#sp-add').addEventListener('click', function(){
@@ -1518,25 +1089,6 @@
       toast('Wpisz nazwę miejsca lub kliknij na mapie, aby dodać punkt.');
     }
   });
-
-
-  // UI
-  $('#sp-add').addEventListener('click', function(){
-    var val=$('#sp-place').value.trim();
-    if(val){
-      geocode(val).then(function(p){
-        points.push({lat:p.lat,lng:p.lng,label:p.label||val}); $('#sp-place').value='';
-        renderList(); recalcRoute(false); updateDerived(); loadGallery();
-      }).catch(function(){ toast('Nie znaleziono'); });
-    } else if(dragMarker && dragMarker.getVisible && dragMarker.getVisible()){
-      var pos=dragMarker.getPosition(); points.push({lat:pos.lat(),lng:pos.lng(),label:'Punkt z mapy'});
-      renderList(); recalcRoute(false); updateDerived(); loadGallery();
-    } else {
-      toast('Wpisz nazwe miejsca lub kliknij na mapie, aby dodac punkt.');
-    }
-  });
-  $('#sp-opt').addEventListener('click', function(){ recalcRoute(true); });
-
   $('#sp-clear').addEventListener('click', function(){
     points=[]; renderList(); clearRenderers(); currentRoutes=[]; activeRouteIndex=0; renderRouteOptions();
     setText('sp-t-time','—'); setText('sp-t-dist','—'); setText('sp-loc','—');
@@ -1558,7 +1110,6 @@
   if(radarToggle){ radarToggle.addEventListener('change', function(e){ pendingRadar=!!e.target.checked; toggleRadar(pendingRadar); updateLink(); }); }
   dEl.addEventListener('change', function(){ updateDerived(); updateSunWeather(); });
 
-
   // suwaki
   function hookSlider(ringId,txtId,sliderId,cb){
     var r=document.getElementById(ringId), t=document.getElementById(txtId), s=document.getElementById(sliderId);
@@ -1573,26 +1124,10 @@
     var base = BASE_URL;
     var joiner = base.indexOf('?') === -1 ? '?' : '&';
     var url = base + joiner + 'sp=' + b64url.enc(packState());
-
-
-  // suwaki
-  function hookSlider(ringId,txtId,sliderId,cb){
-    var r=document.getElementById(ringId), t=document.getElementById(txtId), s=document.getElementById(sliderId);
-    function apply(v){ var rr=+r.getAttribute('r'), per=2*Math.PI*rr, pct=(v-1)/7; r.style.strokeDasharray=per; r.style.strokeDashoffset=per*(1-pct); t.textContent=v+' h'; if(cb) cb(); updateLink(); }
-    s.addEventListener('input', function(e){ apply(+e.target.value); }); apply(+s.value);
-  }
-  hookSlider('sp-ring-rise','sp-txt-rise','sp-slider-rise', updateSunWeather);
-  hookSlider('sp-ring-set','sp-txt-set','sp-slider-set', updateSunWeather);
-
-  // link
-  function updateLink(){
-    var url = BASE_URL + '?sp=' + b64url.enc(packState());
-
     history.replaceState(null,'',url);
     var linkEl=$('#sp-link'); if(linkEl) linkEl.textContent = url;
     if(shortLinkValue){
       shortLinkValue=null;
-
       var box=$('#sp-short-status'); if(box) box.textContent='Plan zmieniony. Wygeneruj nowy krótki link.';
     }
     persistState();
@@ -1603,15 +1138,3 @@
   if(window.google && window.google.maps) startApp();
   window.addEventListener('sunplanner:gmaps-ready', startApp, { once:true });
 })();
-
-      var box=$('#sp-short-status'); if(box) box.textContent='Plan zmieniony. Wygeneruj nowy krotki link.';
-    }
-    persistState();
-  }
-
-  // start
-  function startApp(){ try{ updateSunWeather(); }catch(e){} if(window.google && window.google.maps){ initMap(); } }
-  if(window.google && window.google.maps) startApp();
-  window.addEventListener('sunplanner:gmaps-ready', startApp, { once:true });
-})();
-

--- a/sunplanner.php
+++ b/sunplanner.php
@@ -87,7 +87,7 @@ return new WP_REST_Response(['error' => 'empty'], 400);
 $id = substr(wp_hash($sp . microtime(true)), 0, 8);
 $opt_key = 'sunplanner_share_' . $id;
 add_option($opt_key, $sp, '', 'no');
-$url = add_query_arg('sunplan', $id, home_url('/'));
+$url = home_url('/sp/' . rawurlencode($id) . '/');
 return ['id' => $id, 'url' => $url];
 }
 ]);


### PR DESCRIPTION
## Summary
- restore the planner markup and styles with polished Polish diacritics and enhanced golden-hour highlights
- harden the Rainviewer radar layer with a resilient fallback and keep client card charts embedded
- generate share links under the `/sp/<id>/` slug so created short URLs no longer 404

## Testing
- php -l sunplanner.php

------
https://chatgpt.com/codex/tasks/task_e_68d2c7b3adc08322bbfdf01bb998d01d