### PR TITLE
Ensure SunPlanner assets load as UTF-8

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 :root{--accent:#e94244;--ring-bg:#e5e7eb;}
 *{box-sizing:border-box}
 .sunplanner-wrap{width:100%}

--- a/sunplanner.php
+++ b/sunplanner.php
@@ -59,6 +59,21 @@ wp_localize_script('sunplanner-app', 'SUNPLANNER_CFG', [
 ]);
 });
 
+// Ensure enqueued assets are explicitly marked as UTF-8 for proper character rendering
+add_filter('script_loader_tag', function ($tag, $handle, $src) {
+if ($handle === 'sunplanner-app' && strpos($tag, ' charset=') === false) {
+$tag = str_replace('<script ', '<script charset="utf-8" ', $tag);
+}
+return $tag;
+}, 10, 3);
+
+add_filter('style_loader_tag', function ($html, $handle, $href, $media) {
+if ($handle === 'sunplanner-css' && strpos($html, ' charset=') === false) {
+$html = str_replace('<link ', '<link charset="utf-8" ', $html);
+}
+return $html;
+}, 10, 4);
+
 
 /** === Shortcode === */
 add_shortcode('sunplanner', function () {


### PR DESCRIPTION
## Summary
- add an explicit UTF-8 charset declaration to the public stylesheet
- annotate enqueued SunPlanner assets so WordPress emits charset="utf-8" attributes on the generated tags

## Testing
- php -l sunplanner.php

------
https://chatgpt.com/codex/tasks/task_e_68d399b13fd88322830b2a5bf15d3508