### PR TITLE
Adjust sun planner layout and sharing

### DIFF
--- a/sunplanner-share.php
+++ b/sunplanner-share.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Template for displaying SunPlanner shared plans.
+ *
+ * @package SunPlanner
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+get_header();
+?>
+<main id="primary" class="sunplanner-share" style="min-height:60vh;">
+    <div class="sunplanner-share__inner" style="margin:0 auto;max-width:1200px;padding:2rem 1rem;">
+        <?php echo do_shortcode('[sunplanner]'); ?>
+    </div>
+</main>
+<?php
+get_footer();

--- a/sunplanner.css
+++ b/sunplanner.css
@@ -18,9 +18,10 @@
 .route-card{margin-top:1rem;display:flex;flex-direction:column;gap:1rem}
 .route-card .alt-heading{margin:0}
 .grid2{display:grid;grid-template-columns:1fr;gap:.8rem}
-.golden-block{display:flex;flex-wrap:wrap;gap:1rem;align-items:stretch;margin-top:1rem}
-.golden-block .grid2{flex:1;min-width:260px}
-.glow-info{flex:0 0 200px;min-width:180px;background:linear-gradient(135deg,rgba(253,230,138,.85),rgba(253,186,116,.85));border-radius:16px;padding:1rem;color:#78350f;display:flex;flex-direction:column;justify-content:center;gap:.35rem;box-shadow:0 4px 14px rgba(253,186,116,.25)}
+.golden-block{display:flex;flex-direction:column;gap:1rem;margin-top:1rem}
+.glow-band{display:flex;flex-wrap:wrap;gap:1rem}
+.glow-info{flex:1 1 220px;min-width:200px;background:linear-gradient(135deg,rgba(253,230,138,.85),rgba(253,186,116,.85));border-radius:16px;padding:1rem;color:#78350f;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;gap:.35rem;box-shadow:0 4px 14px rgba(253,186,116,.25)}
+.glow-band .glow-info{flex:1 1 260px}
 .glow-info.align-right{background:linear-gradient(135deg,rgba(191,219,254,.85),rgba(147,197,253,.85));color:#1e3a8a;text-align:right;align-items:flex-end}
 .glow-info h4{margin:0;font-size:1rem;font-weight:600}
 .glow-line{margin:0;font-size:.95rem;font-weight:600;line-height:1.35;text-shadow:0 1px 0 rgba(255,255,255,.45);letter-spacing:.01em}
@@ -57,11 +58,12 @@
 .toolbar .switch{font-size:.9rem;color:#374151}
 .toolbar .switch input{margin-right:.3rem}
 .toolbar .btn{min-width:150px}
-#sp-sun-canvas,#sp-hourly{width:100%;height:170px;border:1px solid #e5e7eb;border-radius:10px;background:#fff}
-.sun-meta{display:flex;flex-wrap:wrap;gap:.75rem;margin:.5rem 0}
-.sun-meta div{flex:1;min-width:150px}
-.sun-meta strong{display:block;font-size:1rem}
-.sun-meta small{display:block;color:#6b7280;margin-top:.2rem}
+#sp-hourly{width:100%;height:170px;border:1px solid #e5e7eb;border-radius:10px;background:#fff}
+.weather-legend{display:flex;gap:1.2rem;align-items:center;flex-wrap:wrap;margin-top:.6rem;font-size:.85rem;color:#374151}
+.weather-legend span{display:inline-flex;align-items:center;gap:.45rem}
+.weather-legend i{display:inline-block;width:16px;height:4px;border-radius:4px;background:#ef4444}
+.weather-legend i.bar{width:12px;height:12px;border-radius:2px;background:rgba(37,99,235,.45)}
+.weather-legend i.line{background:#ef4444;height:2px;width:22px}
 @media(max-width:640px){
   .route-option{min-width:140px}
   .toolbar{flex-direction:column;align-items:flex-start}

--- a/sunplanner.php
+++ b/sunplanner.php
@@ -12,7 +12,7 @@ add_filter('query_vars', function ($vars) { $vars[] = 'sunplan'; return $vars; }
 
 /** === Assets === */
 add_action('wp_enqueue_scripts', function () {
-$ver = '1.7.0';
+$ver = '1.7.1';
 wp_register_style('sunplanner-css', plugins_url('sunplanner.css', __FILE__), [], $ver);
 wp_register_script('sunplanner-app', plugins_url('sunplanner.js', __FILE__), [], $ver, true);
 
@@ -81,8 +81,28 @@ wp_enqueue_style('sunplanner-css');
 wp_enqueue_script('sunplanner-app');
     wp_enqueue_script('sunplanner-gmaps');
     ob_start(); ?>
-<div id="sunplanner-app" class="sunplanner-wrap" data-version="1.7.0"></div>
+<div id="sunplanner-app" class="sunplanner-wrap" data-version="1.7.1"></div>
 <?php return ob_get_clean();
+});
+
+add_filter('template_include', function ($template) {
+    if (get_query_var('sunplan')) {
+        $share_template = plugin_dir_path(__FILE__) . 'sunplanner-share.php';
+        if (file_exists($share_template)) {
+            return $share_template;
+        }
+    }
+    return $template;
+});
+
+add_action('template_redirect', function () {
+    if (get_query_var('sunplan')) {
+        status_header(200);
+        global $wp_query;
+        if ($wp_query) {
+            $wp_query->is_404 = false;
+        }
+    }
 });
 
 


### PR DESCRIPTION
## Summary
- redesign the plan dnia section so sunrise and sunset sit on one row with morning and evening highlights beneath, remove the sun path chart, and add a legend for the hourly weather chart
- correct morning/evening weather data mapping and improve the RainViewer radar overlay fallback
- bump asset versions and serve shared short links through a dedicated template so shared URLs load the planner

## Testing
- php -l sunplanner.php
- php -l sunplanner-share.php

------
https://chatgpt.com/codex/tasks/task_e_68d3b6f479648322a797bcec059834ee