### PR TITLE
Fix sunshine chart availability

### DIFF
--- a/sunplanner.js
+++ b/sunplanner.js
@@ -949,13 +949,31 @@
       ctx.strokeStyle='rgba(148,163,184,0.3)';
       ctx.lineWidth=1;
       ctx.setLineDash([4,6]);
+      ctx.fillStyle='#64748b';
       for(var t=1;t<=4;t++){
         var val=(tickMax/4)*t;
         var y=bottom-(val/tickMax)*barArea;
         ctx.beginPath();
         ctx.moveTo(leftPad,y);
         ctx.lineTo(axisX,y);
-    ctx.stroke();
+        ctx.stroke();
+        ctx.fillText(formatPrec(val)+' mm', axisX+8, y+4);
+      }
+      ctx.setLineDash([]);
+      points.forEach(function(p,idx){
+        if(!p.prec) return;
+        var color=barColor(p.prec);
+        if(!color) return;
+        var x=leftPad+(idx/(points.length-1||1))*chartWidth;
+        var heightPct=Math.min(p.prec,tickMax)/tickMax;
+        var barHeight=heightPct*barArea;
+        var barWidth=Math.max(6,chartWidth/(points.length||1)*0.6);
+        ctx.fillStyle=color;
+        ctx.fillRect(x-barWidth/2, bottom, barWidth, -barHeight);
+      });
+    } else {
+      ctx.setLineDash([]);
+    }
   }
 
   function renderSunshineChart(hourly,dateStr,sunrise,sunset,loading){


### PR DESCRIPTION
## Summary
- ensure the hourly chart helper closes its dashed-grid block so the sunshine chart renderer is defined in the top scope
- restore precipitation grid rendering with labels and column drawing so the hourly chart remains informative

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4196d79f08322ac94820184405edc