### PR TITLE
Add location insights panel with wedding fees and crowd hints

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -38,6 +38,32 @@
 .session-summary__future ul{margin:.35rem 0 0;padding-left:1.2rem}
 .session-summary__future li{margin:.2rem 0}
 .session-summary__tag{display:inline-flex;align-items:center;gap:.25rem;padding:.1rem .45rem;border-radius:999px;background:#e0f2fe;color:#0c4a6e;font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
+.location-insights{margin-top:1rem;padding:1rem;border-radius:12px;background:#f8fafc;border:1px solid #e2e8f0;box-shadow:inset 0 1px 0 rgba(255,255,255,.7)}
+.location-insights h3{margin-top:0;margin-bottom:.35rem;font-size:1.1rem;font-weight:700;color:#0f172a}
+.location-insights__place{margin:0 0 .4rem;font-weight:700;font-size:1.05rem;color:#0f172a}
+.location-insights__grid{display:grid;gap:.9rem}
+.location-insights__section h4{margin:0 0 .3rem;font-size:1rem;font-weight:600;color:#1e293b}
+.location-insights__section p{margin:.2rem 0;font-size:.9rem}
+.location-insights__status{display:inline-flex;align-items:center;gap:.3rem;padding:.25rem .55rem;border-radius:999px;font-size:.78rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
+.location-insights__status--paid{background:#fee2e2;color:#b91c1c}
+.location-insights__status--free{background:#dcfce7;color:#166534}
+.location-insights__status--restricted{background:#fef3c7;color:#92400e}
+.location-insights__note{font-size:.82rem;color:#6b7280;margin-top:.25rem}
+.location-insights__links{margin-top:.35rem}
+.location-insights__links a{color:#1d4ed8;font-weight:600;text-decoration:none}
+.location-insights__links a:hover{text-decoration:underline}
+.crowd-chart{display:flex;align-items:flex-end;gap:6px;margin-top:.75rem;padding-bottom:1.2rem;position:relative}
+.crowd-chart::after{content:'Poziom ruchu (1–5)';position:absolute;right:0;bottom:-1.05rem;font-size:.7rem;color:#9ca3af}
+.crowd-chart__item{flex:1;min-width:36px;text-align:center;font-size:.74rem;color:#475569;position:relative}
+.crowd-chart__bar{width:100%;border-radius:8px 8px 0 0;background:linear-gradient(180deg,rgba(244,63,94,.9),rgba(239,68,68,.75));height:calc((var(--level,0)/var(--max,1))*100%);position:relative;transition:height .2s ease}
+.crowd-chart__bar::before{content:attr(data-level);position:absolute;top:-1.2rem;left:50%;transform:translateX(-50%);font-size:.68rem;font-weight:600;color:#ef4444}
+.crowd-chart__bar[data-level="0"]{background:linear-gradient(180deg,rgba(148,163,184,.45),rgba(203,213,225,.45))}
+.crowd-chart__bar[data-level="1"]{background:linear-gradient(180deg,rgba(16,185,129,.85),rgba(34,197,94,.75))}
+.crowd-chart__bar[data-level="2"]{background:linear-gradient(180deg,rgba(132,204,22,.85),rgba(163,230,53,.75))}
+.crowd-chart__bar[data-level="3"]{background:linear-gradient(180deg,rgba(251,191,36,.85),rgba(245,158,11,.75))}
+.crowd-chart__bar[data-level="4"]{background:linear-gradient(180deg,rgba(249,115,22,.85),rgba(234,88,12,.75))}
+.crowd-chart__bar[data-level="5"]{background:linear-gradient(180deg,rgba(220,38,38,.9),rgba(185,28,28,.8))}
+.crowd-chart__item span{display:block;margin-top:.35rem}
 .route-card{margin-top:1rem;display:flex;flex-direction:column;gap:1rem}
 .route-card .alt-heading{margin:0}
 .grid2{display:grid;grid-template-columns:1fr;gap:.8rem}


### PR DESCRIPTION
## Summary
- add a location insights panel that pulls wedding session fees, drone restrictions and payment links for TPN/TANAP destinations
- seed curated presets for Morskie Oko and Gubałówka with crowd level charts to highlight popular hours
- style the new section and crowd chart so the guidance fits in with the existing planner UI

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d45b1e6f688322a09338d75ec0ed36