### PR TITLE
Simplify location rules and add crowd timing chart

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -40,7 +40,6 @@
 .session-summary__tag{display:inline-flex;align-items:center;gap:.25rem;padding:.1rem .45rem;border-radius:999px;background:#e0f2fe;color:#0c4a6e;font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
 .location-insights{margin-top:1rem;padding:1rem;border-radius:12px;background:#f8fafc;border:1px solid #e2e8f0;box-shadow:inset 0 1px 0 rgba(255,255,255,.7)}
 .location-insights h3{margin-top:0;margin-bottom:.35rem;font-size:1.1rem;font-weight:700;color:#0f172a}
-.location-insights__place{margin:0 0 .4rem;font-weight:700;font-size:1.05rem;color:#0f172a}
 .location-insights__grid{display:grid;gap:.9rem}
 .location-insights__section h4{margin:0 0 .3rem;font-size:1rem;font-weight:600;color:#1e293b}
 .location-insights__section p{margin:.2rem 0;font-size:.9rem}
@@ -48,10 +47,8 @@
 .location-insights__status--paid{background:#fee2e2;color:#b91c1c}
 .location-insights__status--free{background:#dcfce7;color:#166534}
 .location-insights__status--restricted{background:#fef3c7;color:#92400e}
+.location-insights__status--unknown{background:#e5e7eb;color:#374151}
 .location-insights__note{font-size:.82rem;color:#6b7280;margin-top:.25rem}
-.location-insights__links{margin-top:.35rem}
-.location-insights__links a{color:#1d4ed8;font-weight:600;text-decoration:none}
-.location-insights__links a:hover{text-decoration:underline}
 .crowd-chart{display:flex;align-items:flex-end;gap:6px;margin-top:.75rem;padding-bottom:1.2rem;position:relative}
 .crowd-chart::after{content:'Poziom ruchu (1–5)';position:absolute;right:0;bottom:-1.05rem;font-size:.7rem;color:#9ca3af}
 .crowd-chart__item{flex:1;min-width:36px;text-align:center;font-size:.74rem;color:#475569;position:relative}
@@ -138,6 +135,11 @@
 .sunshine-legend i.bar.sun-weak{background:#fef3c7}
 .sunshine-legend i.bar.sun-medium{background:#fcd34d}
 .sunshine-legend i.bar.sun-strong{background:#f59e0b}
+.crowd-block{margin-top:1.2rem;padding:1rem;border-radius:12px;background:#fff7ed;border:1px solid #fcd34d;box-shadow:inset 0 1px 0 rgba(255,255,255,.7)}
+.crowd-block h3{margin:0 0 .5rem;font-size:1rem;font-weight:600;color:#b45309}
+.crowd-block p{margin:.2rem 0;font-size:.9rem;color:#b45309}
+.crowd-block .muted{color:#d97706}
+.crowd-block__note{font-size:.82rem;color:#92400e;margin-top:.4rem}
 .share-card{margin-top:1.2rem}
 .share-card h3{margin-top:0}
 @media(max-width:640px){


### PR DESCRIPTION
## Summary
- streamline the location rules card to focus on paid session status and drone permissions
- surface crowd guidance in a dedicated "Popularne godziny" chart placed under the sunshine block
- restyle the new crowd hint block and status badges to match the simplified content

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d460fb5e248322a501b05c420704d9