### PR TITLE
Add collaborative session planner module

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -49,18 +49,6 @@
 .location-insights__status--restricted{background:#fef3c7;color:#92400e}
 .location-insights__status--unknown{background:#e5e7eb;color:#374151}
 .location-insights__note{font-size:.82rem;color:#6b7280;margin-top:.25rem}
-.crowd-chart{display:flex;align-items:flex-end;gap:6px;margin-top:.75rem;padding-bottom:1.2rem;position:relative}
-.crowd-chart::after{content:'Poziom ruchu (1–5)';position:absolute;right:0;bottom:-1.05rem;font-size:.7rem;color:#9ca3af}
-.crowd-chart__item{flex:1;min-width:36px;text-align:center;font-size:.74rem;color:#475569;position:relative}
-.crowd-chart__bar{width:100%;border-radius:8px 8px 0 0;background:linear-gradient(180deg,rgba(244,63,94,.9),rgba(239,68,68,.75));height:calc((var(--level,0)/var(--max,1))*100%);position:relative;transition:height .2s ease}
-.crowd-chart__bar::before{content:attr(data-level);position:absolute;top:-1.2rem;left:50%;transform:translateX(-50%);font-size:.68rem;font-weight:600;color:#ef4444}
-.crowd-chart__bar[data-level="0"]{background:linear-gradient(180deg,rgba(148,163,184,.45),rgba(203,213,225,.45))}
-.crowd-chart__bar[data-level="1"]{background:linear-gradient(180deg,rgba(16,185,129,.85),rgba(34,197,94,.75))}
-.crowd-chart__bar[data-level="2"]{background:linear-gradient(180deg,rgba(132,204,22,.85),rgba(163,230,53,.75))}
-.crowd-chart__bar[data-level="3"]{background:linear-gradient(180deg,rgba(251,191,36,.85),rgba(245,158,11,.75))}
-.crowd-chart__bar[data-level="4"]{background:linear-gradient(180deg,rgba(249,115,22,.85),rgba(234,88,12,.75))}
-.crowd-chart__bar[data-level="5"]{background:linear-gradient(180deg,rgba(220,38,38,.9),rgba(185,28,28,.8))}
-.crowd-chart__item span{display:block;margin-top:.35rem}
 .route-card{margin-top:1rem;display:flex;flex-direction:column;gap:1rem}
 .route-card .alt-heading{margin:0}
 .grid2{display:grid;grid-template-columns:1fr;gap:.8rem}
@@ -135,21 +123,48 @@
 .sunshine-legend i.bar.sun-weak{background:#fef3c7}
 .sunshine-legend i.bar.sun-medium{background:#fcd34d}
 .sunshine-legend i.bar.sun-strong{background:#f59e0b}
-.crowd-block{margin-top:1.2rem;padding:1rem;border-radius:12px;background:#fff7ed;border:1px solid #fcd34d;box-shadow:inset 0 1px 0 rgba(255,255,255,.7)}
-.crowd-block h3{margin:0 0 .5rem;font-size:1rem;font-weight:600;color:#b45309}
-.crowd-block p{margin:.2rem 0;font-size:.9rem;color:#b45309}
-.crowd-block .muted{color:#d97706}
-.crowd-block__note{font-size:.82rem;color:#92400e;margin-top:.4rem}
 .share-card{margin-top:1.2rem}
 .share-card h3{margin-top:0}
+.planner-card{margin-top:1.2rem}
+.planner-card h3{margin-top:0}
+.planner-grid{display:grid;gap:1rem;margin-top:1rem;grid-template-columns:1fr}
+.planner-section{background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;padding:1rem;display:flex;flex-direction:column;gap:.75rem;box-shadow:inset 0 1px 0 rgba(255,255,255,.7)}
+.planner-section__header h4{margin:0;font-size:1.05rem;font-weight:600;color:#0f172a}
+.planner-section__header p{margin:.2rem 0 0;font-size:.85rem;color:#475569}
+.planner-field{display:flex;flex-direction:column;gap:.35rem;font-size:.85rem;color:#1f2937}
+.planner-field span{font-weight:600}
+.planner-add{display:flex;gap:.5rem;flex-wrap:wrap}
+.planner-add .input{flex:1;min-width:150px}
+.planner-slots{margin-top:.4rem}
+.planner-slot-list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:.6rem}
+.planner-slot{border:1px solid #e2e8f0;border-radius:10px;padding:.6rem .75rem;display:flex;flex-wrap:wrap;gap:.6rem;align-items:center;justify-content:space-between;background:#fff}
+.planner-slot__info{font-weight:600;color:#0f172a;display:flex;flex-direction:column;gap:.25rem}
+.planner-slot__status{font-size:.75rem;font-weight:500;color:#4b5563;background:#e5e7eb;border-radius:999px;padding:.15rem .55rem;display:inline-flex;align-items:center;justify-content:center}
+.planner-slot__actions{display:flex;gap:.45rem;flex-wrap:wrap}
+.planner-slot__btn{padding:.4rem .7rem;border-radius:.6rem;border:1px solid #d1d5db;background:#fff;color:#1f2937;font-size:.85rem;font-weight:600;cursor:pointer;transition:all .18s ease}
+.planner-slot__btn:hover,.planner-slot__btn:focus-visible{border-color:var(--accent);color:#991b1b;outline:none}
+.planner-slot__btn--decline{color:#b91c1c;border-color:#fecaca;background:#fef2f2}
+.planner-slot--accepted{border-color:#16a34a;background:#dcfce7}
+.planner-slot--accepted .planner-slot__status{background:#bbf7d0;color:#166534}
+.planner-slot--declined{border-color:#dc2626;background:#fee2e2}
+.planner-slot--declined .planner-slot__status{background:#fecaca;color:#b91c1c}
+.planner-actions{margin-top:1.2rem;display:flex;flex-direction:column;gap:.6rem}
+.planner-actions__buttons{display:flex;gap:.75rem;flex-wrap:wrap}
+.planner-actions__buttons .btn{flex:1;min-width:160px}
+.planner-actions .muted{font-size:.85rem}
+textarea.input{min-height:96px;resize:vertical}
 @media(max-width:640px){
   .route-option{min-width:140px}
   .toolbar{flex-direction:column;align-items:flex-start}
   .toolbar .btn{width:100%}
   .share-row .btn{min-width:140px}
   .sunplanner-share__title{font-size:1.65rem}
+  .planner-actions__buttons .btn{min-width:140px}
 }
 @media(max-width:780px){
   .glow-info.align-right{text-align:left;align-items:flex-start}
 
+}
+@media(min-width:780px){
+  .planner-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
 }


### PR DESCRIPTION
## Summary
- remove the "Popularne godziny" card and introduce a collaborative session planner under the share tools, including inputs for both parties, slot acceptance/decline buttons and notification controls
- persist the new planner data in the shared state, wire up UI interactions for managing slots and send notification emails through a new REST endpoint

## Testing
- php -l sunplanner.php

------
https://chatgpt.com/codex/tasks/task_e_68d4e38bdbf48322a20ad4b212b17c73