### PR TITLE
Prefer short share link in contact emails

### DIFF
--- a/sunplanner.js
+++ b/sunplanner.js
@@ -665,7 +665,12 @@
     fetch(CONTACT_URL,{
       method:'POST',
       headers:{'Content-Type':'application/json'},
-      body:JSON.stringify({ target:target, state:packState(), link:location.href })
+      body:JSON.stringify({
+        target:target,
+        state:packState(),
+        link:location.href,
+        shortLink: shortLinkValue || ''
+      })
     })
       .then(function(r){
         if(!r.ok) throw new Error('http');


### PR DESCRIPTION
## Summary
- send the saved short share link with contact notifications when available
- ignore empty availability slots when preparing the email payload so proposed terms are listed cleanly

## Testing
- php -l sunplanner.php

------
https://chatgpt.com/codex/tasks/task_e_68d573d1334c8322b1c0ddd9b585e188