### PR TITLE
Stabilize mobile viewport height for shared planner

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -5,6 +5,9 @@
 
 .sunplanner{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;color:#111;line-height:1.45}
 .sunplanner-share{min-height:60vh}
+@supports (min-height: 60svh){
+  .sunplanner-share{min-height:60svh}
+}
 .sunplanner-share__inner{margin:0 auto;max-width:1200px;padding:2rem 1rem}
 .sunplanner-share__header{text-align:center;margin-bottom:2rem}
 .sunplanner-share__badge{display:inline-block;padding:.35rem .75rem;border-radius:999px;background:#fef3c7;color:#92400e;font-weight:600;text-transform:uppercase;letter-spacing:.08em;font-size:.75rem}


### PR DESCRIPTION
## Summary
- replace the mobile share layout's min-height with a static viewport unit when supported to prevent jumping as browser chrome toggles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59a9772408322a3bd1f798f0bb759