### PR TITLE
Improve mobile layout for best days and contact slot inputs

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -37,9 +37,16 @@
 .session-summary__lead{display:block;margin-bottom:.45rem;font-weight:500}
 .session-summary__slots{margin-bottom:.4rem;font-size:.93rem}
 .session-summary__slots span{display:block;margin:.2rem 0}
-.session-summary__future{border-top:1px dashed #cbd5f5;padding-top:.5rem;margin-top:.5rem;font-size:.9rem}
-.session-summary__future ul{margin:.35rem 0 0;padding-left:1.2rem}
-.session-summary__future li{margin:.2rem 0}
+.session-summary__future{border-top:1px dashed #cbd5f5;padding-top:.5rem;margin-top:.5rem;font-size:.92rem}
+.session-summary__future-list{margin:.35rem 0 0;display:flex;flex-direction:column;gap:.45rem}
+.session-summary__future-item{position:relative;display:grid;grid-template-columns:minmax(0,auto) minmax(0,1fr);column-gap:.75rem;row-gap:.2rem;padding:.45rem .65rem .45rem 1.75rem;border-radius:12px;background:#f1f5f9;box-shadow:inset 0 1px 0 rgba(255,255,255,.6)}
+.session-summary__future-item::before{content:"";position:absolute;left:.85rem;top:.85rem;width:.35rem;height:.35rem;border-radius:50%;background:#1d4ed8;box-shadow:0 0 0 4px rgba(37,99,235,.12)}
+.session-summary__future-day{font-weight:700;color:#1e293b;text-transform:capitalize;letter-spacing:.02em}
+.session-summary__future-desc{color:#334155;line-height:1.4}
+@media(max-width:600px){
+  .session-summary__future-item{grid-template-columns:minmax(0,1fr);padding-left:1.5rem}
+  .session-summary__future-desc{grid-column:1/-1;font-size:.88rem}
+}
 .session-summary__tag{display:inline-flex;align-items:center;gap:.25rem;padding:.1rem .45rem;border-radius:999px;background:#e0f2fe;color:#0c4a6e;font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
 .location-insights{margin-top:1rem;padding:1rem;border-radius:12px;background:#f8fafc;border:1px solid #e2e8f0;box-shadow:inset 0 1px 0 rgba(255,255,255,.7)}
 .location-insights h3{margin-top:0;margin-bottom:.35rem;font-size:1.1rem;font-weight:700;color:#0f172a}
@@ -137,7 +144,10 @@
 .contact-section textarea{font-family:inherit}
 .contact-slots{display:flex;flex-direction:column;gap:.6rem;margin:.5rem 0 1rem}
 .contact-slot{position:relative;display:flex;flex-direction:column;gap:.6rem;padding:.75rem;border:1px solid #cbd5f5;border-radius:12px;background:#fff;box-shadow:0 1px 3px rgba(15,23,42,.08)}
-.contact-slot-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:.5rem}
+.contact-slot-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:.5rem}
+.contact-slot-field{display:flex;flex-direction:column;gap:.25rem}
+.contact-slot-hint{font-size:.78rem;font-weight:600;color:#475569}
+.contact-slot-field .input{min-width:0}
 .contact-slot-actions{display:flex;flex-wrap:wrap;gap:.45rem}
 .contact-slot .btn{flex:1;min-width:140px}
 .contact-slot-badge{position:absolute;top:-10px;right:12px;display:inline-flex;align-items:center;gap:.25rem;padding:.2rem .55rem;border-radius:999px;background:#15803d;color:#f0fdf4;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;box-shadow:0 4px 12px rgba(21,128,61,.25)}
@@ -154,6 +164,11 @@
 @media(min-width:860px){.contact-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
 .share-card{margin-top:1.2rem}
 .share-card h3{margin-top:0}
+@media(max-width:600px){
+  .contact-slot-row{grid-template-columns:minmax(0,1fr)}
+  .contact-slot-actions{flex-direction:column}
+  .contact-slot .btn{width:100%;min-width:0}
+}
 @media(max-width:640px){
   .route-option{min-width:140px}
   .toolbar{flex-direction:column;align-items:flex-start}

--- a/sunplanner.js
+++ b/sunplanner.js
@@ -321,6 +321,7 @@
       date.type='date';
       date.className='input contact-slot-input';
       date.value=slot.date||'';
+      date.placeholder='2025-09-29';
       var handleDateChange=function(e){ contactState[key][idx].date=e.target.value; updateLink(); };
       date.addEventListener('input', handleDateChange);
       date.addEventListener('change', handleDateChange);
@@ -328,11 +329,26 @@
       time.type='time';
       time.className='input contact-slot-input';
       time.value=slot.time||'';
+      time.placeholder='18:30';
       var handleTimeChange=function(e){ contactState[key][idx].time=e.target.value; updateLink(); };
       time.addEventListener('input', handleTimeChange);
       time.addEventListener('change', handleTimeChange);
-      fields.appendChild(date);
-      fields.appendChild(time);
+      var dateWrap=document.createElement('label');
+      dateWrap.className='contact-slot-field';
+      var dateHint=document.createElement('span');
+      dateHint.className='contact-slot-hint';
+      dateHint.textContent='Data (np. 2025-09-29)';
+      dateWrap.appendChild(dateHint);
+      dateWrap.appendChild(date);
+      var timeWrap=document.createElement('label');
+      timeWrap.className='contact-slot-field';
+      var timeHint=document.createElement('span');
+      timeHint.className='contact-slot-hint';
+      timeHint.textContent='Godzina (np. 18:30)';
+      timeWrap.appendChild(timeHint);
+      timeWrap.appendChild(time);
+      fields.appendChild(dateWrap);
+      fields.appendChild(timeWrap);
 
       var actions=document.createElement('div');
       actions.className='contact-slot-actions';
@@ -1447,8 +1463,13 @@
     var top=days.filter(function(d){ return d.score>=45; }).slice(0,3);
     if(!top.length) top=days.slice(0,3);
     if(!top.length) return '';
-    var items=top.map(function(d){ return '<li><strong>'+d.label+'</strong> – '+d.desc+'</li>'; }).join('');
-    return '<div class="session-summary__future"><strong>Najlepsze dni w ciągu 10 dni</strong><ul>'+items+'</ul></div>';
+    var items=top.map(function(d){
+      return '<div class="session-summary__future-item">'
+        +'<span class="session-summary__future-day">'+d.label+'</span>'
+        +'<span class="session-summary__future-desc">'+d.desc+'</span>'
+        +'</div>';
+    }).join('');
+    return '<div class="session-summary__future"><strong>Najlepsze dni w ciągu 10 dni</strong><div class="session-summary__future-list">'+items+'</div></div>';
   }
   function renderSessionSummary(data,dateStr){
     if(!data){ sessionSummaryNoData(); return; }


### PR DESCRIPTION
## Summary
- restyled the best-day forecast list with a card layout that keeps copy aligned on small screens
- added labeled wrappers and responsive sizing for contact slot date/time fields so hints stay visible on mobile

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d636b0f0e08322a56a11c5053701a0