### PR TITLE
Revamp planner contact workflow for three roles

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -135,33 +135,57 @@
 .sunshine-legend i.bar.sun-strong{background:#f59e0b}
 .contact-card{margin-top:1.2rem}
 .contact-card h3{margin-top:0}
-.contact-grid{display:grid;gap:1rem;margin-top:.9rem}
-.contact-section{background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;padding:1rem;display:flex;flex-direction:column;gap:.6rem;box-shadow:inset 0 1px 0 rgba(255,255,255,.6)}
-.contact-section h4{margin:0;font-size:1.05rem;font-weight:600;color:#0f172a}
-.contact-label{font-size:.85rem;font-weight:600;color:#475569}
 .contact-card .input{width:100%}
 .input.textarea{min-height:110px;resize:vertical}
-.contact-section textarea{font-family:inherit}
-.contact-slots{display:flex;flex-direction:column;gap:.6rem;margin:.5rem 0 1rem}
-.contact-slot{position:relative;display:flex;flex-direction:column;gap:.6rem;padding:.75rem;border:1px solid #cbd5f5;border-radius:12px;background:#fff;box-shadow:0 1px 3px rgba(15,23,42,.08)}
-.contact-slot-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:.5rem}
-.contact-slot-field{display:flex;flex-direction:column;gap:.25rem}
-.contact-slot-hint{font-size:.78rem;font-weight:600;color:#475569}
-.contact-slot-field .input{min-width:0}
-.contact-slot-actions{display:flex;flex-wrap:wrap;gap:.45rem}
-.contact-slot .btn{flex:1;min-width:140px}
-.contact-slot-badge{position:absolute;top:-10px;right:12px;display:inline-flex;align-items:center;gap:.25rem;padding:.2rem .55rem;border-radius:999px;background:#15803d;color:#f0fdf4;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;box-shadow:0 4px 12px rgba(21,128,61,.25)}
-.contact-slot--selected{border-color:#16a34a;background:#dcfce7}
-.contact-slot--selected .contact-slot-badge{display:inline-flex}
-.contact-slot--selected .contact-slot-actions .btn{border-color:#15803d;color:#14532d}
-.contact-slot-empty{padding:.65rem .8rem;border:1px dashed #cbd5f5;border-radius:10px;background:#f1f5f9;color:#475569;text-align:center;font-size:.85rem}
-.contact-actions{display:flex;flex-direction:column;gap:.6rem;margin-top:1.2rem}
-.contact-actions .btn{min-width:200px}
-.contact-status{min-height:1.2rem;font-size:.85rem}
-.contact-status.is-ok{color:#166534}
-.contact-status.is-error{color:#b91c1c}
-.contact-status.is-pending{color:#92400e}
-@media(min-width:860px){.contact-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+.contact-roles{display:flex;flex-direction:column;gap:.75rem;margin-top:.85rem}
+.contact-role-row{display:grid;grid-template-columns:110px repeat(2,minmax(0,1fr));align-items:center;gap:.75rem;padding:.85rem;border:1px solid #e2e8f0;border-radius:12px;background:#f8fafc}
+.contact-role-label{font-weight:600;color:#0f172a}
+.contact-role-row .input{width:100%}
+.contact-notes{margin-top:1.2rem}
+.contact-notes-grid{display:grid;gap:.75rem}
+.contact-note{display:flex;flex-direction:column;gap:.45rem}
+.contact-note-label{font-size:.85rem;font-weight:600;color:#475569}
+.contact-note textarea{min-height:110px;resize:vertical;font-family:inherit}
+.contact-schedule{margin-top:1.2rem;display:flex;flex-direction:column;gap:.85rem}
+.slot-list{display:flex;flex-direction:column;gap:.75rem}
+.slot-empty{padding:.75rem;border:1px dashed #cbd5f5;border-radius:12px;background:#f8fafc;color:#475569;font-size:.9rem;text-align:center}
+.slot-item{border:1px solid #cbd5f5;border-radius:14px;background:#fff;box-shadow:0 1px 3px rgba(15,23,42,.08);padding:.9rem;display:flex;flex-direction:column;gap:.55rem}
+.slot-item-header{display:flex;align-items:center;justify-content:space-between;gap:.75rem}
+.slot-item-title{font-weight:600;color:#0f172a;font-size:1rem}
+.slot-status-badge{display:inline-flex;align-items:center;gap:.35rem;padding:.25rem .65rem;border-radius:999px;font-size:.72rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
+.slot-item-meta{font-size:.88rem;color:#334155}
+.slot-item-location{font-size:.85rem;color:#1f2937;font-weight:500}
+.slot-item-author{font-size:.78rem;color:#475569}
+.slot-item-conflict{font-size:.78rem;font-weight:600;color:#b91c1c}
+.slot-item--conflict{border-style:dashed}
+.slot-actions{display:flex;flex-wrap:wrap;gap:.55rem}
+.slot-actions .btn{min-width:130px;flex:1}
+.slot-action-export{color:#0f172a;border-color:#cbd5f5}
+.slot-status-proposed{background:#f8fafc;border-color:#cbd5f5}
+.slot-status-proposed .slot-status-badge{background:#e2e8f0;color:#1f2937}
+.slot-status-confirmed{background:#dcfce7;border-color:#16a34a}
+.slot-status-confirmed .slot-status-badge{background:#16a34a;color:#f0fdf4}
+.slot-status-rejected{background:#fee2e2;border-color:#b91c1c}
+.slot-status-rejected .slot-status-badge{background:#b91c1c;color:#fef2f2}
+.slot-form{background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;padding:1rem;display:flex;flex-direction:column;gap:.85rem}
+.slot-form-row{display:grid;gap:.75rem;grid-template-columns:repeat(auto-fit,minmax(140px,1fr))}
+.slot-field{display:flex;flex-direction:column;gap:.35rem}
+.slot-field-label{font-size:.85rem;font-weight:600;color:#475569}
+.slot-field-wide{grid-column:span 2}
+.slot-field-actions{display:flex;align-items:flex-end}
+.slot-field-actions .btn{width:100%}
+@media(min-width:860px){.contact-notes-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
+@media(max-width:760px){
+  .contact-role-row{grid-template-columns:minmax(0,1fr)}
+  .contact-role-label{font-size:.9rem}
+  .slot-field-wide{grid-column:auto}
+}
+@media(max-width:600px){
+  .slot-actions{flex-direction:column}
+  .slot-actions .btn{min-width:0;width:100%}
+  .slot-form-row{grid-template-columns:minmax(0,1fr)}
+  .slot-field-wide{grid-column:auto}
+}
 .share-card{margin-top:1.2rem}
 .share-card h3{margin-top:0}
 @media(max-width:600px){


### PR DESCRIPTION
## Summary
- rebuild the contact section to cover the couple, photographer, and videographer roles with per-role notes
- implement the scheduling workflow with proposed/confirmed/rejected states, autosave+URL serialization, conflict detection, ICS export, and a notification stub
- keep slot identifiers stable when restoring saved plans by recalculating the slot counter from persisted data

## Testing
- not run (manual verification recommended)


------
https://chatgpt.com/codex/tasks/task_e_68d6b4aa399483229baf75a855dba49d