### PR TITLE
Expand contact workflow for all wedding roles

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -138,7 +138,7 @@
 .contact-card .input{width:100%}
 .input.textarea{min-height:110px;resize:vertical}
 .contact-roles{display:flex;flex-direction:column;gap:.75rem;margin-top:.85rem}
-.contact-role-row{display:grid;grid-template-columns:110px repeat(2,minmax(0,1fr));align-items:center;gap:.75rem;padding:.85rem;border:1px solid #e2e8f0;border-radius:12px;background:#f8fafc}
+.contact-role-row{display:grid;grid-template-columns:140px repeat(2,minmax(0,1fr));align-items:center;gap:.75rem;padding:.85rem;border:1px solid #e2e8f0;border-radius:12px;background:#f8fafc}
 .contact-role-label{font-weight:600;color:#0f172a}
 .contact-role-row .input{width:100%}
 .contact-notes{margin-top:1.2rem}

--- a/sunplanner.php
+++ b/sunplanner.php
@@ -350,6 +350,129 @@ function sunplanner_contact_prepare_slots($slots)
     return $prepared;
 }
 
+function sunplanner_contact_extract_role_email($contact, $role)
+{
+    if (!is_array($contact)) {
+        return '';
+    }
+
+    $key = $role . 'Email';
+    if (isset($contact[$key])) {
+        $email = sanitize_email($contact[$key]);
+        if ($email !== '') {
+            return $email;
+        }
+    }
+
+    if (isset($contact['roles']) && is_array($contact['roles'])) {
+        $roles = $contact['roles'];
+        if (isset($roles[$role]) && is_array($roles[$role]) && isset($roles[$role]['email'])) {
+            $email = sanitize_email($roles[$role]['email']);
+            if ($email !== '') {
+                return $email;
+            }
+        }
+    }
+
+    return '';
+}
+
+function sunplanner_contact_role_label($role)
+{
+    switch ($role) {
+        case 'couple':
+            return __('Młoda para', 'sunplanner');
+        case 'photographer':
+            return __('Fotograf', 'sunplanner');
+        case 'videographer':
+            return __('Filmowiec', 'sunplanner');
+        default:
+            return $role;
+    }
+}
+
+function sunplanner_contact_event_label($event)
+{
+    switch ($event) {
+        case 'slot:proposed':
+            return __('Propozycja terminu', 'sunplanner');
+        case 'slot:confirmed':
+            return __('Potwierdzenie terminu', 'sunplanner');
+        case 'slot:rejected':
+            return __('Odrzucenie terminu', 'sunplanner');
+        case 'slot:removed':
+            return __('Usunięcie terminu', 'sunplanner');
+        default:
+            return '';
+    }
+}
+
+function sunplanner_contact_slot_details_lines($slot)
+{
+    if (!is_array($slot)) {
+        return [];
+    }
+
+    $lines = [];
+
+    $date = isset($slot['date']) ? $slot['date'] : '';
+    $date_label = sunplanner_contact_format_plan_date($date);
+
+    $time = isset($slot['time']) ? substr((string) $slot['time'], 0, 5) : '';
+    if (!preg_match('/^\d{2}:\d{2}$/', $time)) {
+        $time = '';
+    }
+
+    if ($date_label || $time) {
+        if ($date_label && $time) {
+            $lines[] = sprintf(__('Termin: %s o %s', 'sunplanner'), $date_label, $time);
+        } elseif ($date_label) {
+            $lines[] = sprintf(__('Termin: %s', 'sunplanner'), $date_label);
+        } else {
+            $lines[] = sprintf(__('Termin: %s', 'sunplanner'), $time);
+        }
+    }
+
+    if (!empty($slot['title'])) {
+        $lines[] = sprintf(__('Tytuł: %s', 'sunplanner'), sanitize_text_field($slot['title']));
+    }
+
+    if (!empty($slot['location'])) {
+        $lines[] = sprintf(__('Miejsce: %s', 'sunplanner'), sanitize_text_field($slot['location']));
+    }
+
+    if (!empty($slot['duration'])) {
+        $duration = absint($slot['duration']);
+        if ($duration > 0) {
+            $lines[] = sprintf(
+                __('Czas trwania: %s', 'sunplanner'),
+                sprintf(_n('%d minuta', '%d minut', $duration, 'sunplanner'), $duration)
+            );
+        }
+    }
+
+    if (!empty($slot['status'])) {
+        $status = sanitize_key($slot['status']);
+        $status_label = '';
+        switch ($status) {
+            case 'proposed':
+                $status_label = __('Proponowany', 'sunplanner');
+                break;
+            case 'confirmed':
+                $status_label = __('Potwierdzony', 'sunplanner');
+                break;
+            case 'rejected':
+                $status_label = __('Odrzucony', 'sunplanner');
+                break;
+        }
+        if ($status_label) {
+            $lines[] = sprintf(__('Status: %s', 'sunplanner'), $status_label);
+        }
+    }
+
+    return array_values(array_filter(array_map('trim', $lines)));
+}
+
 function sunplanner_contact_format_slot_line($slot)
 {
     $slot = is_array($slot) ? $slot : [];
@@ -405,15 +528,25 @@ function sunplanner_handle_contact_request(WP_REST_Request $req)
     }
 
     $target = isset($params['target']) ? sanitize_key($params['target']) : '';
-    if (!in_array($target, ['photographer', 'couple'], true)) {
+    if (!in_array($target, ['photographer', 'couple', 'videographer'], true)) {
         return new WP_REST_Response(['error' => 'invalid_target'], 400);
     }
 
     $state = isset($params['state']) && is_array($params['state']) ? $params['state'] : [];
     $contact = isset($state['contact']) && is_array($state['contact']) ? $state['contact'] : [];
 
-    $couple_email = isset($contact['coupleEmail']) ? sanitize_email($contact['coupleEmail']) : '';
-    $phot_email = isset($contact['photographerEmail']) ? sanitize_email($contact['photographerEmail']) : '';
+    $couple_email = sunplanner_contact_extract_role_email($contact, 'couple');
+    $phot_email = sunplanner_contact_extract_role_email($contact, 'photographer');
+    $video_email = sunplanner_contact_extract_role_email($contact, 'videographer');
+
+    $actor = isset($params['actor']) ? sanitize_key($params['actor']) : '';
+    if (!in_array($actor, ['couple', 'photographer', 'videographer'], true)) {
+        $actor = '';
+    }
+
+    $event = isset($params['event']) ? sanitize_text_field($params['event']) : '';
+    $slot_payload = isset($params['slot']) && is_array($params['slot']) ? $params['slot'] : [];
+    $slot_details = sunplanner_contact_slot_details_lines($slot_payload);
 
     $home = home_url();
 
@@ -438,21 +571,69 @@ function sunplanner_handle_contact_request(WP_REST_Request $req)
         }
     }
 
-    $recipient = $target === 'photographer' ? $phot_email : $couple_email;
+    switch ($target) {
+        case 'photographer':
+            $recipient = $phot_email;
+            break;
+        case 'videographer':
+            $recipient = $video_email;
+            break;
+        default:
+            $recipient = $couple_email;
+            break;
+    }
     if ($recipient === '') {
         return new WP_REST_Response(['error' => 'missing_email'], 400);
     }
 
-    $reply_to = $target === 'photographer' ? $couple_email : $phot_email;
+    $reply_to = '';
+    if ($actor === 'couple') {
+        $reply_to = $couple_email;
+    } elseif ($actor === 'photographer') {
+        $reply_to = $phot_email;
+    } elseif ($actor === 'videographer') {
+        $reply_to = $video_email;
+    }
+    if ($reply_to === '') {
+        if ($target === 'photographer') {
+            $reply_to = $couple_email ? $couple_email : $video_email;
+        } elseif ($target === 'videographer') {
+            $reply_to = $couple_email ? $couple_email : $phot_email;
+        } else {
+            $reply_to = $phot_email ? $phot_email : $video_email;
+        }
+    }
     $site_name = wp_specialchars_decode(get_bloginfo('name'), ENT_QUOTES);
 
-    $subject = sprintf(__('SunPlanner: formularz został zaktualizowany (%s)', 'sunplanner'), $site_name ? $site_name : 'SunPlanner');
+    $actor_label = $actor ? sunplanner_contact_role_label($actor) : '';
+    $event_label = sunplanner_contact_event_label($event);
+
+    $subject_parts = [];
+    if ($event_label !== '') {
+        $subject_parts[] = $event_label;
+    }
+    if ($actor_label !== '') {
+        $subject_parts[] = $actor_label;
+    }
+    if ($site_name) {
+        $subject_parts[] = $site_name;
+    }
+    if (!$subject_parts) {
+        $subject_parts[] = __('Aktualizacja planu', 'sunplanner');
+    }
+    $subject = sprintf(__('SunPlanner: %s', 'sunplanner'), implode(' – ', $subject_parts));
 
     $lines = [];
     $lines[] = __('Cześć!', 'sunplanner');
-    $lines[] = __('Formularz planowania sesji został zaktualizowany.', 'sunplanner');
+    $lines[] = __('Otrzymaliśmy aktualizację zapytania o sesję plenerową w SunPlannerze.', 'sunplanner');
     if ($site_name) {
         $lines[] = sprintf(__('Plan pochodzi ze strony: %s', 'sunplanner'), $site_name);
+    }
+    if ($actor_label !== '') {
+        $lines[] = sprintf(__('Autor aktualizacji: %s', 'sunplanner'), $actor_label);
+    }
+    if ($event_label !== '') {
+        $lines[] = sprintf(__('Typ zmiany: %s', 'sunplanner'), $event_label);
     }
     if ($destination !== '') {
         $lines[] = sprintf(__('Cel sesji: %s', 'sunplanner'), $destination);
@@ -461,13 +642,21 @@ function sunplanner_handle_contact_request(WP_REST_Request $req)
         $lines[] = sprintf(__('Podgląd planu: %s', 'sunplanner'), $preview_link);
     }
 
+    if (!empty($slot_details)) {
+        $lines[] = '';
+        $lines[] = __('Szczegóły terminu:', 'sunplanner');
+        foreach ($slot_details as $line) {
+            $lines[] = $line;
+        }
+    }
+
     $lines[] = '';
-    $lines[] = __('Otrzymaliśmy nowy plan pleneru. Szczegóły znajdziesz w SunPlannerze.', 'sunplanner');
+    $lines[] = __('Aktualne terminy znajdziesz w SunPlannerze.', 'sunplanner');
     $lines[] = '';
     $lines[] = __('Wiadomość wygenerowana automatycznie w SunPlanner.', 'sunplanner');
 
     $headers = ['Content-Type: text/plain; charset=UTF-8'];
-    if ($reply_to) {
+    if ($reply_to && $reply_to !== $recipient) {
         $headers[] = 'Reply-To: ' . $reply_to;
     }
 


### PR DESCRIPTION
## Summary
- rename the couple contact fields to "Młoda para" and widen the contact grid so the three roles stack correctly.
- add full notification delivery logic that emails the other two roles whenever one participant proposes or updates a slot, including videographer support.
- prevent deleting slots added by the couple and enrich the REST contact handler with role-aware messaging and recipients.

## Testing
- php -l sunplanner.php

------
https://chatgpt.com/codex/tasks/task_e_68d6c7dbfd308322abeb6e8e94bea8bd