### PR TITLE
Add inline validation to slot scheduling form

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -19,6 +19,7 @@
 .rowd{display:flex;justify-content:space-between;align-items:center;margin:.25rem 0}
 .col{display:flex;flex-direction:column}
 .input{flex:1;min-width:180px;padding:.55rem .7rem;border:1px solid #d1d5db;border-radius:.5rem;font-size:1rem}
+.input.input-error{border-color:#f87171;box-shadow:0 0 0 1px rgba(248,113,113,.35)}
 
 .btn{padding:.55rem .9rem;border-radius:.5rem;border:1px solid var(--accent);background:var(--accent);color:#fff;cursor:pointer;transition:all .18s ease;font-weight:600;box-shadow:0 2px 6px rgba(233,66,68,.18)}
 .btn:hover,.btn:focus-visible{transform:translateY(-1px);box-shadow:0 8px 18px rgba(233,66,68,.25)}
@@ -172,8 +173,9 @@
 .slot-field{display:flex;flex-direction:column;gap:.35rem}
 .slot-field-label{font-size:.85rem;font-weight:600;color:#475569}
 .slot-field-wide{grid-column:span 2}
-.slot-field-actions{display:flex;align-items:flex-end}
+.slot-field-actions{display:flex;flex-direction:column;justify-content:flex-end;align-items:stretch;gap:.35rem}
 .slot-field-actions .btn{width:100%}
+.slot-form-error{display:none;font-size:.85rem;font-weight:600;color:#b91c1c}
 @media(min-width:860px){.contact-notes-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
 @media(max-width:760px){
   .contact-role-row{grid-template-columns:minmax(0,1fr)}

--- a/sunplanner.js
+++ b/sunplanner.js
@@ -277,6 +277,7 @@
             '</label>'+
             '<div class="slot-field slot-field-actions">'+
               '<button id="sp-slot-add" class="btn" type="button">Dodaj termin</button>'+
+              '<div id="sp-slot-error" class="slot-form-error" role="alert" aria-live="assertive"></div>'+
             '</div>'+
           '</div>'+
         '</div>'+
@@ -366,7 +367,8 @@
     duration: document.getElementById('sp-slot-duration'),
     title: document.getElementById('sp-slot-title'),
     location: document.getElementById('sp-slot-location'),
-    addBtn: document.getElementById('sp-slot-add')
+    addBtn: document.getElementById('sp-slot-add'),
+    errorBox: document.getElementById('sp-slot-error')
   };
 
   // contact helpers & rendering
@@ -694,6 +696,45 @@
     updateLink();
   }
 
+  function clearSlotFieldError(field){
+    if(!field) return;
+    var hadError=field.classList && field.classList.contains('input-error');
+    field.classList.remove('input-error');
+    field.removeAttribute('aria-invalid');
+    if(hadError && slotForm.errorBox){
+      slotForm.errorBox.textContent='';
+      slotForm.errorBox.style.display='none';
+    }
+  }
+
+  function clearSlotFormErrors(){
+    ['date','time','duration','title'].forEach(function(key){
+      var field=slotForm[key];
+      if(field){
+        field.classList.remove('input-error');
+        field.removeAttribute('aria-invalid');
+      }
+    });
+    if(slotForm.errorBox){
+      slotForm.errorBox.textContent='';
+      slotForm.errorBox.style.display='none';
+    }
+  }
+
+  function showSlotFormError(message, field){
+    if(slotForm.errorBox){
+      slotForm.errorBox.textContent=message;
+      slotForm.errorBox.style.display='block';
+    }
+    if(field){
+      field.classList.add('input-error');
+      field.setAttribute('aria-invalid','true');
+      if(typeof field.focus==='function'){
+        field.focus();
+      }
+    }
+  }
+
   function handleAddSlot(){
     var actor=getActiveRole();
     var date=slotForm.date?slotForm.date.value:'';
@@ -701,10 +742,11 @@
     var duration=parseInt(slotForm.duration && slotForm.duration.value,10);
     var title=slotForm.title?slotForm.title.value.trim():'';
     var location=slotForm.location?slotForm.location.value.trim():'';
-    if(!date || !time || !(duration>0) || !title){
-      toast('Uzupełnij datę, godzinę, czas i tytuł terminu.');
-      return;
-    }
+    clearSlotFormErrors();
+    if(!date){ showSlotFormError('Uzupełnij datę terminu.', slotForm.date); return; }
+    if(!time){ showSlotFormError('Dodaj godzinę terminu.', slotForm.time); return; }
+    if(!(duration>0)){ showSlotFormError('Podaj czas trwania w minutach.', slotForm.duration); return; }
+    if(!title){ showSlotFormError('Dodaj tytuł terminu.', slotForm.title); return; }
     var slot=normalizeSlot({ date:date, time:time, duration:duration, title:title, location:location, createdBy:actor, status:SLOT_STATUSES.PROPOSED }, actor);
     contactState.slots.push(slot);
     notifyContacts('slot:proposed',{actor:actor,slot:cloneSlot(slot)});
@@ -2399,6 +2441,13 @@
     }
   });
   if(slotForm.addBtn){ slotForm.addBtn.addEventListener('click', handleAddSlot); }
+  ['date','time','duration','title'].forEach(function(key){
+    var field=slotForm[key];
+    if(!field) return;
+    var reset=function(){ clearSlotFieldError(field); };
+    field.addEventListener('input', reset);
+    field.addEventListener('change', reset);
+  });
   var radarToggle=$('#sp-radar');
   if(radarToggle){ radarToggle.addEventListener('change', function(e){ pendingRadar=!!e.target.checked; toggleRadar(pendingRadar); updateLink(); }); }
   dEl.addEventListener('change', function(){ updateDerived(); updateSunWeather(); });


### PR DESCRIPTION
## Summary
- show inline validation feedback in the appointment form so missing data is clearly highlighted
- adjust the slot form layout and styling to accommodate the error message and error field state

## Testing
- Manual Playwright check of slot form validation

------
https://chatgpt.com/codex/tasks/task_e_68d6cbd6984483229444b4e2072a37f1