### PR TITLE
Add provider notification share button

### DIFF
--- a/sunplanner.js
+++ b/sunplanner.js
@@ -1,5 +1,5 @@
 
-/* SunPlanner v1.7.3 - rozbudowany planer z planowaniem słońca, radarową warstwą mapy, autosave i eksportami */
+/* SunPlanner v1.7.5 - rozbudowany planer z planowaniem słońca, radarową warstwą mapy, autosave i eksportami */
 
 (function(){
   var CFG = window.SUNPLANNER_CFG || {};
@@ -371,6 +371,7 @@
       '<div class="row share-row" style="align-items:flex-start">'+
         '<div class="col" style="flex:1">'+
           '<div class="row" style="gap:.35rem;flex-wrap:wrap">'+
+            '<button id="sp-send-link" class="btn" type="button">Wyślij link do usługodawców</button>'+
             '<button id="sp-copy" class="btn secondary" type="button">Kopiuj link</button>'+
             '<button id="sp-short" class="btn secondary" type="button">Krótki link</button>'+
             '<button id="sp-ics" class="btn secondary" type="button">Eksport do kalendarza</button>'+
@@ -2504,6 +2505,10 @@
     var txt=linkEl?linkEl.textContent:location.href;
     try{ navigator.clipboard.writeText(txt); toast('Skopiowano link','ok'); }
     catch(e){ toast('Link gotowy'); }
+  });
+  $('#sp-send-link').addEventListener('click', function(){
+    updateLink();
+    notifyContacts('plan:shared');
   });
   $('#sp-short').addEventListener('click', createShortLink);
   $('#sp-ics').addEventListener('click', exportCalendar);

--- a/sunplanner.php
+++ b/sunplanner.php
@@ -23,7 +23,7 @@ add_filter('query_vars', function ($vars) { $vars[] = 'sunplan'; return $vars; }
 /** === Assets === */
 
 add_action('wp_enqueue_scripts', function () {
-$ver = '1.7.4';
+$ver = '1.7.5';
 wp_register_style('sunplanner-css', plugins_url('sunplanner.css', __FILE__), [], $ver);
 wp_register_script('sunplanner-app', plugins_url('sunplanner.js', __FILE__), [], $ver, true);
 
@@ -94,7 +94,7 @@ wp_enqueue_style('sunplanner-css');
 wp_enqueue_script('sunplanner-app');
     wp_enqueue_script('sunplanner-gmaps');
     ob_start(); ?>
-<div id="sunplanner-app" class="sunplanner-wrap" data-version="1.7.4"></div>
+<div id="sunplanner-app" class="sunplanner-wrap" data-version="1.7.5"></div>
 <?php return ob_get_clean();
 });
 
@@ -402,6 +402,8 @@ function sunplanner_contact_event_label($event)
             return __('Odrzucenie terminu', 'sunplanner');
         case 'slot:removed':
             return __('Usunięcie terminu', 'sunplanner');
+        case 'plan:shared':
+            return __('Udostępnienie planu', 'sunplanner');
         default:
             return '';
     }


### PR DESCRIPTION
## Summary
- add a primary share button that sends the SunPlanner link to service providers and triggers contact notifications
- bump the frontend asset version and add a label for the new plan sharing notification event

## Testing
- php -l allemedia/sunplanner.php

------
https://chatgpt.com/codex/tasks/task_e_68d6d70817b883228939ab1eb820162f