### PR TITLE
Add manual control for slot notifications

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -142,6 +142,8 @@
 .contact-role-row{display:grid;grid-template-columns:140px repeat(2,minmax(0,1fr));align-items:center;gap:.75rem;padding:.85rem;border:1px solid #e2e8f0;border-radius:12px;background:#f8fafc}
 .contact-role-label{font-weight:600;color:#0f172a}
 .contact-role-row .input{width:100%}
+.contact-role-action{grid-column:1/-1}
+.contact-role-action .btn{width:100%}
 .contact-notes{margin-top:1.2rem}
 .contact-notes-grid{display:grid;gap:.75rem}
 .contact-note{display:flex;flex-direction:column;gap:.45rem}

--- a/sunplanner.php
+++ b/sunplanner.php
@@ -404,6 +404,8 @@ function sunplanner_contact_event_label($event)
             return __('Usunięcie terminu', 'sunplanner');
         case 'plan:shared':
             return __('Udostępnienie planu', 'sunplanner');
+        case 'contact:reply':
+            return __('Odpowiedź do pary młodej', 'sunplanner');
         default:
             return '';
     }


### PR DESCRIPTION
## Summary
- add a dedicated "Wyślij do usługodawców" control so proposed slots no longer trigger emails automatically
- let photographer and videographer reply to the couple from the contact card and surface the new event label in PHP
- adjust styling and state management to support the new buttons and relaxed slot title requirement

## Testing
- php -l sunplanner.php

------
https://chatgpt.com/codex/tasks/task_e_68d6df94f70c8322a25fcef7206512e6