### PR TITLE
Adjust session proposal notifications

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -177,6 +177,8 @@
 .slot-field-wide{grid-column:span 2}
 .slot-field-actions{display:flex;flex-direction:column;justify-content:flex-end;align-items:stretch;gap:.35rem}
 .slot-field-actions .btn{width:100%}
+.slot-notify-all{margin-top:.4rem}
+.slot-notify-all .btn{width:100%}
 .slot-form-error{display:none;font-size:.85rem;font-weight:600;color:#b91c1c}
 @media(min-width:860px){.contact-notes-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
 @media(max-width:760px){

--- a/sunplanner.js
+++ b/sunplanner.js
@@ -373,10 +373,12 @@
             '</label>'+
             '<div class="slot-field slot-field-actions">'+
               '<button id="sp-slot-add" class="btn" type="button">Dodaj termin</button>'+
-              '<button id="sp-slot-notify" class="btn secondary" type="button">Wyślij do usługodawców</button>'+
               '<div id="sp-slot-error" class="slot-form-error" role="alert" aria-live="assertive"></div>'+
             '</div>'+
           '</div>'+
+        '</div>'+
+        '<div class="slot-notify-all">'+
+          '<button id="sp-slot-notify" class="btn secondary" type="button">Powiadom wszystkich o propozycji sesji</button>'+
         '</div>'+
       '</div>'+
     '</div>'+
@@ -385,7 +387,6 @@
       '<div class="row share-row" style="align-items:flex-start">'+
         '<div class="col" style="flex:1">'+
           '<div class="row" style="gap:.35rem;flex-wrap:wrap">'+
-            '<button id="sp-send-link" class="btn" type="button">Wyślij link do usługodawców</button>'+
             '<button id="sp-copy" class="btn secondary" type="button">Kopiuj link</button>'+
             '<button id="sp-short" class="btn secondary" type="button">Krótki link</button>'+
             '<button id="sp-ics" class="btn secondary" type="button">Eksport do kalendarza</button>'+
@@ -854,7 +855,7 @@
     contactState.slots.push(slot);
     renderSlotList();
     updateLink();
-    toast('Termin zapisany. Wyślij go do usługodawców, gdy będzie gotowy.','ok');
+    toast('Termin zapisany. Powiadom wszystkich o propozycji sesji, gdy będzie gotowy.','ok');
   }
 
   function handleNotifyPendingSlots(){
@@ -2546,10 +2547,6 @@
     var txt=linkEl?linkEl.textContent:location.href;
     try{ navigator.clipboard.writeText(txt); toast('Skopiowano link','ok'); }
     catch(e){ toast('Link gotowy'); }
-  });
-  $('#sp-send-link').addEventListener('click', function(){
-    updateLink();
-    notifyContacts('plan:shared');
   });
   $('#sp-short').addEventListener('click', createShortLink);
   $('#sp-ics').addEventListener('click', exportCalendar);


### PR DESCRIPTION
## Summary
- update the session proposal actions so the notification button sits below the form with clearer copy
- remove the provider email share button and refresh copy to reinforce manual notifications
- add styling to keep the new notification button full width beneath the form

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d796a382548322837b41c4c5f66cec