### PR TITLE
Rearrange plan day metadata layout

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -33,6 +33,12 @@
 .cards{display:grid;grid-template-columns:1fr;gap:1rem;margin-top:1rem}
 .card{background:#fff;border-radius:12px;box-shadow:0 4px 14px rgba(0,0,0,.07);padding:1rem}
 .card.inner{box-shadow:none;border:1px solid #e5e7eb;border-radius:12px;background:#fff}
+.session-meta{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:.75rem;margin:.75rem 0 1rem}
+.session-meta__item{display:flex;flex-direction:column;gap:.3rem;padding:.75rem .95rem;border-radius:14px;background:linear-gradient(135deg,rgba(254,226,226,.95),rgba(255,255,255,.95));border:1px solid #fecaca;box-shadow:0 6px 16px rgba(248,113,113,.12);min-height:90px;position:relative;overflow:hidden}
+.session-meta__item:nth-child(2n){background:linear-gradient(135deg,rgba(219,234,254,.95),rgba(255,255,255,.97));border-color:#bfdbfe;box-shadow:0 6px 16px rgba(59,130,246,.1)}
+.session-meta__item::after{content:"";position:absolute;inset:auto -30% -45% auto;width:120px;height:120px;border-radius:999px;background:rgba(255,255,255,.65);pointer-events:none;transform:rotate(25deg)}
+.session-meta__label{font-size:.78rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:#475569}
+.session-meta__value{font-size:1.15rem;color:#0f172a;word-break:break-word}
 .session-summary{margin:.6rem 0 1rem;padding:.85rem 1rem;border-radius:12px;background:#f8fafc;border:1px solid #e2e8f0;color:#1e293b;font-size:.95rem;line-height:1.5;box-shadow:inset 0 1px 0 rgba(255,255,255,.7)}
 .session-summary strong{display:block;font-size:1.05rem;margin-bottom:.3rem;color:#0f172a}
 .session-summary__lead{display:block;margin-bottom:.45rem;font-weight:500}

--- a/sunplanner.js
+++ b/sunplanner.js
@@ -296,14 +296,28 @@
     '<div class="cards">'+
       '<div class="card">'+
         '<h3>Plan dnia – przebieg zdjęć</h3>'+
+        '<div class="session-meta" aria-label="Kluczowe informacje o planie dnia">'+
+          '<div class="session-meta__item">'+
+            '<span class="session-meta__label">Cel podróży</span>'+
+            '<strong id="sp-loc" class="session-meta__value">—</strong>'+
+          '</div>'+
+          '<div class="session-meta__item">'+
+            '<span class="session-meta__label">Data realizacji</span>'+
+            '<strong id="sp-date-label" class="session-meta__value">—</strong>'+
+          '</div>'+
+          '<div class="session-meta__item">'+
+            '<span class="session-meta__label">Czas jazdy</span>'+
+            '<strong id="sp-t-time" class="session-meta__value">—</strong>'+
+          '</div>'+
+          '<div class="session-meta__item">'+
+            '<span class="session-meta__label">Dystans trasy</span>'+
+            '<strong id="sp-t-dist" class="session-meta__value">—</strong>'+
+          '</div>'+
+        '</div>'+
         '<div id="sp-session-summary" class="session-summary">'+
           '<strong>Wybierz lokalizację i datę</strong>'+
           '<span class="session-summary__lead">Dodaj cel podróży, aby ocenić warunki sesji w plenerze.</span>'+
         '</div>'+
-          '<div class="rowd"><span>Cel (ostatni punkt)</span><strong id="sp-loc">—</strong></div>'+
-          '<div class="rowd"><span>Data</span><strong id="sp-date-label">—</strong></div>'+
-          '<div class="rowd"><span>Czas jazdy</span><strong id="sp-t-time">—</strong></div>'+
-          '<div class="rowd"><span>Dystans</span><strong id="sp-t-dist">—</strong></div>'+
 
           '<div class="ten-day-forecast card inner">'+
             '<h4>10-dniowa prognoza: temperatura i opady</h4>'+


### PR DESCRIPTION
## Summary
- move key plan metadata directly below the "Plan dnia" heading in the shared planner view
- restyle the goal, date, travel time, and distance values with a dedicated session meta layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbbc4233608322b86eb47407b4520c