### PR TITLE
Reorder weather charts and align headings

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -132,7 +132,9 @@
 .weather-legend i.bar.medium{background:#60a5fa}
 .weather-legend i.bar.heavy{background:#1e3a8a}
 .sunshine-block{margin-top:1.2rem}
-.sunshine-block h3{margin:0 0 .6rem;font-size:1rem;font-weight:600;color:#b45309}
+.sunshine-block .chart-header{gap:.25rem}
+.sunshine-block .chart-header h3{font-size:1rem;color:#b45309}
+.sunshine-block .chart-header .chart-description{font-size:.85rem}
 .sunshine-canvas{height:160px;min-height:160px;background:#fffbeb;border:1px solid #fcd34d}
 .sunshine-legend{margin-top:.55rem;color:#b45309}
 .sunshine-legend span{color:#b45309;font-weight:500}
@@ -142,7 +144,6 @@
 .sunshine-legend i.bar.sun-strong{background:#f59e0b}
 .ten-day-forecast{margin-top:1.2rem;padding:1rem;display:flex;flex-direction:column;gap:.75rem}
 .card.ten-day-forecast{background:#f8fafc;border:1px solid #e2e8f0}
-.ten-day-forecast h4{margin:0;font-size:1.05rem;font-weight:600;color:#0f172a}
 .ten-day-canvas{width:100%;height:210px;min-height:210px;border:1px solid #e2e8f0;border-radius:12px;background:#fff}
 .ten-day-legend{display:flex;flex-wrap:wrap;gap:.75rem;font-size:.85rem;color:#475569}
 .ten-day-legend span{display:inline-flex;align-items:center;gap:.4rem}
@@ -152,7 +153,10 @@
 .ten-day-legend i.bar{width:16px;height:14px}
 .ten-day-legend i.bar.rain{background:rgba(37,99,235,.35)}
 .plan-day-hourly{margin-top:1.2rem}
-.plan-day-hourly h3{margin-top:0}
+
+.chart-header{display:flex;flex-direction:column;gap:.35rem}
+.chart-header h3{margin:0;font-size:1.05rem;font-weight:600;color:#0f172a}
+.chart-description{margin:0;font-size:.9rem;color:#475569;line-height:1.45}
 .plan-day-gallery{margin-top:1.2rem}
 .plan-day-gallery h3{margin-top:0}
 .contact-card{margin-top:1.2rem}

--- a/sunplanner.js
+++ b/sunplanner.js
@@ -320,12 +320,43 @@
         '</div>'+
 
           '<div class="ten-day-forecast card inner">'+
-            '<h4>10-dniowa prognoza: temperatura i opady</h4>'+
+            '<div class="chart-header">'+
+              '<h3>Prognoza pogody – 10 dni</h3>'+
+              '<p class="chart-description">Temperatura maksymalna i minimalna oraz suma opadów w kolejnych dniach.</p>'+
+            '</div>'+
             '<canvas id="sp-ten-day" class="ten-day-canvas" aria-label="10-dniowa prognoza temperatury i opadów"></canvas>'+
             '<div class="ten-day-legend">'+
               '<span><i class="line max"></i>Maks. temp.</span>'+
               '<span><i class="line min"></i>Min. temp.</span>'+
               '<span><i class="bar rain"></i>Opady (mm)</span>'+
+            '</div>'+
+          '</div>'+
+
+          '<div class="card inner plan-day-hourly">'+
+            '<div class="chart-header">'+
+              '<h3>Prognoza godzinowa – temperatura i opady</h3>'+
+              '<p class="chart-description">Temperatura powietrza oraz prognozowane natężenie opadów dla wybranej lokalizacji.</p>'+
+            '</div>'+
+            '<canvas id="sp-hourly" class="smallcanvas" aria-label="Prognoza godzinowa"></canvas>'+
+            '<div class="weather-legend">'+
+
+              '<span><i class="line"></i>Temperatura (°C)</span>'+
+              '<span><i class="bar weak"></i>Opady 0–0,5 mm</span>'+
+              '<span><i class="bar medium"></i>Opady 0,6–2 mm</span>'+
+              '<span><i class="bar heavy"></i>Opady powyżej 2 mm</span>'+
+
+            '</div>'+
+            '<div class="sunshine-block">'+
+              '<div class="chart-header">'+
+                '<h3>Prognoza godzinowa – nasłonecznienie</h3>'+
+                '<p class="chart-description">Szacowana liczba minut ze słońcem w każdej godzinie.</p>'+
+              '</div>'+
+              '<canvas id="sp-sunshine" class="smallcanvas sunshine-canvas" aria-label="Godziny nasłonecznienia"></canvas>'+
+              '<div class="weather-legend sunshine-legend">'+
+                '<span><i class="bar sun-weak"></i>Przebłyski</span>'+
+                '<span><i class="bar sun-medium"></i>Słońce przez część godziny</span>'+
+                '<span><i class="bar sun-strong"></i>Pełne słońce</span>'+
+              '</div>'+
             '</div>'+
           '</div>'+
 
@@ -390,28 +421,6 @@
           '</div>'+
 
         '</div>'+
-
-          '<div class="card inner plan-day-hourly">'+
-            '<h3>Mini-wykres godzinowy – prognoza pogody</h3>'+
-            '<canvas id="sp-hourly" class="smallcanvas" aria-label="Prognoza godzinowa"></canvas>'+
-            '<div class="weather-legend">'+
-
-              '<span><i class="line"></i>Temperatura (°C)</span>'+
-              '<span><i class="bar weak"></i>Opady 0–0,5 mm</span>'+
-              '<span><i class="bar medium"></i>Opady 0,6–2 mm</span>'+
-              '<span><i class="bar heavy"></i>Opady powyżej 2 mm</span>'+
-
-            '</div>'+
-            '<div class="sunshine-block">'+
-              '<h3>Godziny ze słońcem</h3>'+
-              '<canvas id="sp-sunshine" class="smallcanvas sunshine-canvas" aria-label="Godziny nasłonecznienia"></canvas>'+
-              '<div class="weather-legend sunshine-legend">'+
-                '<span><i class="bar sun-weak"></i>Przebłyski</span>'+
-                '<span><i class="bar sun-medium"></i>Słońce przez część godziny</span>'+
-                '<span><i class="bar sun-strong"></i>Pełne słońce</span>'+
-              '</div>'+
-            '</div>'+
-          '</div>'+
 
           '<div class="card inner plan-day-gallery">'+
             '<h3>Galeria inspiracji – zdjęcia</h3>'+


### PR DESCRIPTION
## Summary
- move the hourly weather and sunshine charts directly beneath the ten-day forecast block
- standardize chart headings and add descriptive captions explaining the displayed data
- introduce shared styling hooks for the updated chart headers and descriptions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbbe5eedfc8322b0a66632145a0d8b