### PR TITLE
Improve mobile weather forecast display

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -152,6 +152,13 @@
 .ten-day-legend i.bar.rain{background:rgba(37,99,235,.35)}
 .plan-day-hourly{margin-top:1.2rem}
 
+@media(max-width:600px){
+  .ten-day-forecast .chart-header{align-items:center}
+  .ten-day-forecast .chart-header,
+  .ten-day-forecast .chart-header h3{width:100%}
+  .ten-day-forecast .chart-header h3{text-align:center}
+}
+
 .chart-header{display:flex;flex-direction:column;gap:.35rem}
 .chart-header h3{margin:0;font-size:1.05rem;font-weight:600;color:#0f172a}
 .chart-description{margin:0;font-size:.9rem;color:#475569;line-height:1.45}


### PR DESCRIPTION
## Summary
- ensure forecast metadata is defined before rendering and simplify the weather forecast heading copy
- rotate precipitation and sunshine value labels vertically on compact canvases to improve mobile readability
- tweak mobile styles so the forecast heading stretches across the card width

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbf862e63483228532536fba029490