### PR TITLE
Improve mobile forecast chart legibility

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -159,6 +159,11 @@
   .ten-day-forecast .chart-header h3{text-align:center}
 }
 
+@media(max-width:640px){
+  .ten-day-forecast.card.inner{padding-left:.5rem;padding-right:.5rem}
+  .ten-day-forecast.card.inner .ten-day-canvas{margin-left:-.25rem;margin-right:-.25rem;width:calc(100% + .5rem)}
+}
+
 .chart-header{display:flex;flex-direction:column;gap:.35rem}
 .chart-header h3{margin:0;font-size:1.05rem;font-weight:600;color:#0f172a}
 .chart-description{margin:0;font-size:.9rem;color:#475569;line-height:1.45}

--- a/sunplanner.js
+++ b/sunplanner.js
@@ -2203,19 +2203,19 @@
     var ultraCompact=width<=360;
     ctx.font=(ultraCompact?'11px':'12px')+' system-ui, sans-serif';
     ctx.fillStyle='#64748b';
-    var leftPad=54;
-    var rightPad=48;
+    var leftPad=52;
+    var rightPad=46;
     var topPad=28;
     var bottomPad=36;
     if(compact){
-      leftPad=44;
-      rightPad=36;
+      leftPad=38;
+      rightPad=32;
       topPad=26;
-      bottomPad=34;
+      bottomPad=32;
     }
     if(ultraCompact){
-      leftPad=34;
-      rightPad=28;
+      leftPad=30;
+      rightPad=26;
       topPad=24;
       bottomPad=30;
     }
@@ -2362,7 +2362,8 @@
         var labelValue=p.rain>=1?p.rain.toFixed(1):p.rain.toFixed(2);
         labelValue=labelValue.replace(/\.0+$/,'').replace(/(\.\d*[1-9])0+$/,'$1');
         var rainLabel=labelValue+' mm';
-        ctx.fillStyle='#1d4ed8';
+        var labelColor=p.rain>=2?'#e0f2fe':'#1d4ed8';
+        ctx.fillStyle=labelColor;
         ctx.font=rainLabelFont;
         if(useVerticalRainLabels){
           var textLength=ctx.measureText(rainLabel).width;
@@ -2371,7 +2372,7 @@
           var maxCenter=bottom-10;
           if(centerY<minCenter) centerY=minCenter;
           if(centerY>maxCenter) centerY=maxCenter;
-          drawVerticalText(ctx,rainLabel,x,centerY,{font:rainLabelFont,fillStyle:'#1d4ed8'});
+          drawVerticalText(ctx,rainLabel,x,centerY,{font:rainLabelFont,fillStyle:labelColor});
         } else {
           ctx.save();
           ctx.translate(x, bottom-barHeight-6);


### PR DESCRIPTION
## Summary
- reduce padding on the 10-day forecast card on small screens so the chart can use more horizontal space
- adjust the 10-day forecast rendering to use slimmer margins on compact widths and brighten rain labels when precipitation is heavy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0385de50832290983134648b93ac