### PR TITLE
Add scrollable 16-day forecast chart highlighting sunshine

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -142,6 +142,22 @@
 .sunshine-legend i.bar.sun-weak{background:#fef3c7}
 .sunshine-legend i.bar.sun-medium{background:#fcd34d}
 .sunshine-legend i.bar.sun-strong{background:#f59e0b}
+.daily16-block{margin-top:1.4rem}
+.daily16-chart-container{position:relative;overflow-x:auto;margin-top:.75rem;padding-bottom:.65rem}
+.daily16-chart-container::-webkit-scrollbar{height:8px}
+.daily16-chart-container::-webkit-scrollbar-track{background:rgba(226,232,240,.6);border-radius:999px}
+.daily16-chart-container::-webkit-scrollbar-thumb{background:rgba(148,163,184,.75);border-radius:999px}
+.daily16-chart-container{scrollbar-width:thin;scrollbar-color:rgba(148,163,184,.75) rgba(226,232,240,.6)}
+.daily16-canvas{min-height:320px;height:320px;border:1px solid #e2e8f0;border-radius:14px;background:#fff}
+.daily16-empty{margin-top:.4rem;text-align:center}
+.daily16-legend{margin-top:.75rem}
+.daily16-legend i{display:inline-block;border-radius:999px}
+.daily16-legend i.line{width:26px;height:3px;background:#ef4444}
+.daily16-legend i.line.min{background:#2563eb}
+.daily16-legend i.line.max{background:#ef4444}
+.daily16-legend i.bar.sun{background:#f59e0b}
+.daily16-legend i.bar.rain{background:rgba(37,99,235,.35)}
+.daily16-note{margin-top:.65rem}
 .ten-day-forecast{margin-top:1.2rem;padding:1rem;display:flex;flex-direction:column;gap:.75rem}
 .card.ten-day-forecast{background:#f8fafc;border:1px solid #e2e8f0}
 .ten-day-canvas{width:100%;height:210px;min-height:210px;border:1px solid #e2e8f0;border-radius:12px;background:#fff}


### PR DESCRIPTION
## Summary
- replace the daily 16-day forecast strip with a horizontally scrollable chart that plots temperature, rainfall and sunshine in a single view
- request sunshine duration data from Open-Meteo and surface it in the new visualization with updated legend and styles
- highlight the couple-confirmed wedding date in the chart and refresh the view whenever slots change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcb775f554832296cf24942947ce7f