### PR TITLE
Add slider to daily forecast chart to prevent stretching

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -148,6 +148,8 @@
 .daily16-chart-container::-webkit-scrollbar-track{background:rgba(226,232,240,.6);border-radius:999px}
 .daily16-chart-container::-webkit-scrollbar-thumb{background:rgba(148,163,184,.75);border-radius:999px}
 .daily16-chart-container{scrollbar-width:thin;scrollbar-color:rgba(148,163,184,.75) rgba(226,232,240,.6)}
+.daily16-slider{margin-top:.5rem}
+.daily16-slider .slider{width:100%}
 .daily16-canvas{min-height:320px;height:320px;border:1px solid #e2e8f0;border-radius:14px;background:#fff}
 .daily16-empty{margin-top:.4rem;text-align:center}
 .daily16-legend{margin-top:.75rem}


### PR DESCRIPTION
## Summary
- add view state management for the 16-day forecast chart and limit canvas width to the route column
- render a movable window of daily data with a range slider instead of stretching the plan-day table
- style the new slider control to integrate with existing layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcc5924c648322ba6ce312ea3c4cd2