### PR TITLE
Improve plan day table responsiveness

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -16,7 +16,8 @@
 .sunplanner-share__desc a{color:inherit;text-decoration:underline}
 
 .row{display:flex;gap:.6rem;flex-wrap:wrap;margin:.6rem 0}
-.rowd{display:flex;justify-content:space-between;align-items:center;margin:.25rem 0}
+.rowd{display:flex;justify-content:space-between;align-items:center;margin:.25rem 0;gap:.35rem;flex-wrap:wrap}
+.rowd strong{flex:0 0 auto}
 .col{display:flex;flex-direction:column}
 .input{flex:1;min-width:180px;padding:.55rem .7rem;border:1px solid #d1d5db;border-radius:.5rem;font-size:1rem}
 .input.input-error{border-color:#f87171;box-shadow:0 0 0 1px rgba(248,113,113,.35)}
@@ -75,8 +76,24 @@
 .glow-info h4{margin:0;font-size:1rem;font-weight:600}
 .glow-line{margin:0;font-size:.95rem;font-weight:600;line-height:1.35;text-shadow:0 1px 0 rgba(255,255,255,.45);letter-spacing:.01em}
 @media(min-width:980px){.cards{grid-template-columns:1fr}.grid2{grid-template-columns:1fr 1fr}}
+@media(max-width:720px){
+  .session-meta{grid-template-columns:minmax(0,1fr)}
+  .kpi{grid-template-columns:repeat(auto-fit,minmax(140px,1fr));row-gap:.6rem}
+}
+@media(max-width:560px){
+  .rowd{flex-direction:column;align-items:flex-start}
+  .rowd strong{width:100%;text-align:left}
+  .kpi{grid-template-columns:minmax(0,1fr)}
+  .sunplanner .table-scroll table{min-width:420px}
+}
 .muted{color:#6b7280;font-size:.9rem}
 .badge{margin:.35rem 0;padding:.25rem .5rem;background:#f3f4f6;border-radius:6px;display:inline-block;font-size:.85rem;color:#374151}
+.sunplanner table{width:100%;border-collapse:collapse;font-size:.95rem}
+.sunplanner table th,.sunplanner table td{padding:.5rem .65rem;text-align:left;border-bottom:1px solid #e5e7eb;word-break:break-word}
+.sunplanner table thead th{background:#f8fafc;color:#1e293b;font-weight:600}
+.sunplanner table tbody tr:nth-child(2n){background:#f9fafb}
+.sunplanner .table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.sunplanner .table-scroll table{min-width:520px}
 
 .kpi{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.25rem .8rem;margin-top:.35rem}
 .waypoint{display:flex;justify-content:space-between;align-items:center;border:1px dashed #d1d5db;border-radius:10px;padding:.45rem .6rem;margin:.35rem 0}

--- a/sunplanner.js
+++ b/sunplanner.js
@@ -683,7 +683,23 @@
   }
 
   function summaryElement(){ return document.getElementById('sp-session-summary'); }
-  function setSessionSummary(html){ var el=summaryElement(); if(el){ el.innerHTML=html; } }
+  enhanceTables(root);
+
+  function enhanceTables(scope){
+    if(!scope || !scope.querySelectorAll) return;
+    var tables=scope.querySelectorAll('table');
+    Array.prototype.forEach.call(tables,function(table){
+      if(!table || table.closest('.table-scroll')) return;
+      var wrap=document.createElement('div');
+      wrap.className='table-scroll';
+      if(table.parentNode){
+        table.parentNode.insertBefore(wrap, table);
+        wrap.appendChild(table);
+      }
+    });
+  }
+
+  function setSessionSummary(html){ var el=summaryElement(); if(el){ el.innerHTML=html; enhanceTables(el); } }
   function sessionSummaryDefault(){ setSessionSummary('<strong>Wybierz lokalizację i datę</strong><span class="session-summary__lead">Dodaj cel podróży, aby ocenić warunki sesji w plenerze.</span>'); }
   function sessionSummaryLoading(){ setSessionSummary('<strong>Analizuję prognozę…</strong><span class="session-summary__lead">Sprawdzam pogodę i najlepsze okna na zdjęcia.</span>'); }
   function sessionSummaryNoData(){ setSessionSummary('<strong>Brak prognozy pogodowej</strong><span class="session-summary__lead">Spróbuj ponownie później lub wybierz inną lokalizację.</span>'); }


### PR DESCRIPTION
## Summary
- add responsive table styles and overflow handling to the shared plan view
- wrap dynamically rendered tables so plan-day content can scroll on narrow screens
- tweak plan-day row and KPI layouts to stack more gracefully on small devices

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd4bd32bb08322a91fde258a708fb1