### PR TITLE
Adjust desktop inspiration gallery layout

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -233,10 +233,11 @@ td .gallery-inspirations figure,td .gallery-inspirations p{margin:0}
   .gallery-inspirations-grid{grid-template-columns:repeat(4,1fr)}
 }
 @media(min-width:1024px){
+  .plan-day-gallery{grid-column:1/-1}
   .gallery-inspirations{display:block}
-  .gallery-inspirations-grid{display:grid!important;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:clamp(12px,1.2vw,20px);width:100%;max-width:100%}
-  .gallery-track{display:grid!important;grid-template-columns:unset;grid-auto-flow:column;grid-auto-columns:minmax(340px,1fr);gap:clamp(12px,1.2vw,20px);width:100%;max-width:100%;overflow-x:auto;scroll-snap-type:x proximity;-webkit-overflow-scrolling:touch}
-  .gallery-track .gallery-item{scroll-snap-align:start}
+  .gallery-inspirations-grid{display:grid!important;grid-template-columns:repeat(6,minmax(0,1fr));gap:clamp(12px,1.2vw,20px);width:100%;max-width:100%}
+  .gallery-track{display:grid!important;grid-template-columns:repeat(6,minmax(0,1fr));grid-auto-flow:row;gap:clamp(12px,1.2vw,20px);width:100%;max-width:100%;overflow-x:visible;scroll-snap-type:none;-webkit-overflow-scrolling:auto}
+  .gallery-track .gallery-item{scroll-snap-align:unset}
   .gallery-item{border-radius:12px;overflow:hidden}
   .gallery-link{border-radius:12px}
   .gallery-item img{aspect-ratio:16/9}

--- a/sunplanner.js
+++ b/sunplanner.js
@@ -3501,7 +3501,7 @@
     if(!label){ gal.innerHTML=''; return; }
     gal.innerHTML='<div class="muted">Ładuję zdjęcia...</div>';
 
-    var sizeAttr='(min-width:1200px) 25vw, (min-width:768px) 33vw, (max-width:480px) 48vw, 100vw';
+    var sizeAttr='(min-width:1200px) 18vw, (min-width:1024px) 20vw, (min-width:768px) 33vw, (max-width:480px) 48vw, 100vw';
 
     function normalizeAlt(text){
       if(typeof text==='string' && text.trim()){ return text.trim(); }
@@ -3634,7 +3634,7 @@
     }
 
     function fetchUnsplashItems(){
-      return fetch('https://api.unsplash.com/search/photos?per_page=6&query='+encodeURIComponent(label+' wedding shoot')+'&client_id='+UNSPLASH_KEY)
+      return fetch('https://api.unsplash.com/search/photos?per_page=12&query='+encodeURIComponent(label+' wedding shoot')+'&orientation=landscape&client_id='+UNSPLASH_KEY)
         .then(function(r){ return r.json(); })
         .then(function(d){
           var arr=(d && d.results)? d.results : [];


### PR DESCRIPTION
## Summary
- expand the inspiration gallery card to span the full planner width on desktop
- lay out six inspiration tiles in a single desktop grid instead of a horizontal scroller
- tweak responsive image sizing and Unsplash query to keep six landscape photos available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de69358760832293382c6ba4d5aa3c