### PR TITLE
Update inspiration gallery pagination and contact form layout

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -211,11 +211,14 @@ html,body{overflow-x:hidden}
 .plan-day-gallery__nav{display:inline-flex;align-items:center;gap:clamp(8px,2vw,16px)}
 .gallery-nav{display:inline-flex;align-items:center;justify-content:center;width:clamp(36px,6vw,44px);height:clamp(36px,6vw,44px);border-radius:50%;border:1px solid #d1d5db;background:#fff;color:#0f172a;font-size:clamp(1rem,2.2vw,1.2rem);line-height:1;cursor:pointer;transition:background .2s ease,border-color .2s ease}
 .gallery-nav:hover,.gallery-nav:focus-visible{background:#0f172a;color:#fff;border-color:#0f172a;outline:2px solid rgba(15,23,42,.6);outline-offset:2px}
+.gallery-nav[disabled],.gallery-nav[aria-disabled="true"]{opacity:.45;cursor:default;pointer-events:none}
 .gallery-inspirations{width:100%;max-width:100%}
 td .gallery-inspirations,th .gallery-inspirations{width:100%!important;max-width:100%!important;margin:0;padding:0}
-.gallery-inspirations-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:clamp(8px,1.2vw,16px);width:100%;max-width:100%;min-width:0}
+.gallery-inspirations-grid{display:grid;grid-template-columns:repeat(1,minmax(0,1fr));gap:clamp(12px,1.2vw,20px);width:100%;max-width:100%;min-width:0;overflow:hidden}
 .gallery-inspirations-grid:focus-visible{outline:2px solid rgba(15,23,42,.35);outline-offset:4px}
+.gallery-track{position:relative}
 .gallery-item{min-width:0;margin:0}
+.gallery-item.is-hidden{display:none!important}
 .gallery-link{display:block;border-radius:10px;overflow:hidden;box-shadow:0 6px 16px rgba(15,23,42,.12);transition:transform .25s ease,box-shadow .25s ease}
 .gallery-link:focus-visible,.gallery-link:hover{transform:translateY(-2px);box-shadow:0 10px 24px rgba(15,23,42,.18)}
 .gallery-link:focus-visible{outline:2px solid rgba(15,23,42,.45);outline-offset:4px}
@@ -223,21 +226,16 @@ td .gallery-inspirations,th .gallery-inspirations{width:100%!important;max-width
 td .gallery-inspirations figure,td .gallery-inspirations p{margin:0}
 .gallery-inspirations,.gallery-inspirations *{max-width:100%}
 .table-responsive{overflow-x:auto}
-@media(max-width:480px){
-  .gallery-inspirations-grid{grid-template-columns:repeat(2,1fr)}
+@media(min-width:640px){
+  .gallery-inspirations-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
 }
-@media(min-width:768px){
-  .gallery-inspirations-grid{grid-template-columns:repeat(3,1fr)}
-}
-@media(min-width:1200px){
-  .gallery-inspirations-grid{grid-template-columns:repeat(4,1fr)}
+@media(min-width:1024px){
+  .gallery-inspirations-grid{grid-template-columns:repeat(3,minmax(0,1fr))}
 }
 @media(min-width:1024px){
   .plan-day-gallery{grid-column:1/-1}
   .gallery-inspirations{display:block}
-  .gallery-inspirations-grid{display:grid!important;grid-template-columns:repeat(6,minmax(0,1fr));gap:clamp(12px,1.2vw,20px);width:100%;max-width:100%}
-  .gallery-track{display:grid!important;grid-template-columns:repeat(6,minmax(0,1fr));grid-auto-flow:row;gap:clamp(12px,1.2vw,20px);width:100%;max-width:100%;overflow-x:visible;scroll-snap-type:none;-webkit-overflow-scrolling:auto}
-  .gallery-track .gallery-item{scroll-snap-align:unset}
+  .gallery-inspirations-grid{display:grid!important}
   .gallery-item{border-radius:12px;overflow:hidden}
   .gallery-link{border-radius:12px}
   .gallery-item img{aspect-ratio:16/9}
@@ -251,8 +249,8 @@ td .gallery-inspirations figure,td .gallery-inspirations p{margin:0}
 .input.textarea{min-height:110px;resize:vertical}
 .contact-roles{display:grid;grid-template-columns:minmax(0,1fr);gap:clamp(12px,2vw,24px)}
 .contact-role-row{display:grid;grid-template-columns:minmax(0,1fr);align-items:flex-start;gap:clamp(8px,1.6vw,16px);padding:clamp(16px,3vw,24px);border:1px solid #e2e8f0;border-radius:18px;background:#f8fafc;min-width:0}
-.contact-role-label{font-weight:600;color:#0f172a;font-size:clamp(.95rem,1.8vw,1.05rem)}
-.contact-role-row .input{width:100%;min-width:0}
+.contact-role-label{font-weight:600;color:#0f172a;font-size:clamp(.95rem,1.8vw,1.05rem);grid-column:1/-1}
+.contact-role-row .input{width:100%;min-width:0;grid-column:1/-1}
 .contact-notes{display:flex;flex-direction:column;gap:clamp(12px,2vw,20px)}
 .contact-notes-grid{display:grid;gap:clamp(12px,2vw,20px);grid-template-columns:minmax(0,1fr)}
 .contact-note{display:flex;flex-direction:column;gap:clamp(8px,1.5vw,16px)}
@@ -311,7 +309,6 @@ td .gallery-inspirations figure,td .gallery-inspirations p{margin:0}
   .contact-notes-grid{grid-template-columns:repeat(3,minmax(0,1fr))}
   .slot-list{grid-template-columns:repeat(3,minmax(0,1fr))}
   .contact-role-row{grid-template-columns:minmax(0,160px) repeat(2,minmax(0,1fr));align-items:center}
-  .contact-role-label{grid-column:auto}
   .slot-field-wide{grid-column:span 2}
 }
 .share-card{margin-top:1.2rem}


### PR DESCRIPTION
## Summary
- display the inspiration gallery in three-image pages with navigation that toggles the visible set
- tweak gallery controls to disable when unavailable and adapt image sizing for larger previews
- stack contact role inputs beneath their labels so the couple email field is full-width and more visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de6dcb7a9c832289f025cc0250414f