### PR TITLE
Add Open-Meteo hourly forecast visualisations

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -138,6 +138,7 @@ html,body{overflow-x:hidden}
 .toolbar .switch{font-size:.9rem;color:#374151}
 .toolbar .btn{min-width:150px}
 #sp-hourly{width:100%;height:170px;min-height:170px;border:1px solid #e5e7eb;border-radius:10px;background:#fff}
+#sp-hourly,#sp-sunshine{image-rendering:-webkit-optimize-contrast}
 .chart-legend{display:flex;flex-wrap:wrap;gap:.75rem;align-items:center;font-size:.85rem;font-weight:500;color:#1f2937}
 .chart-legend span{display:inline-flex;align-items:center;gap:.4rem}
 .weather-legend{margin-top:.6rem}


### PR DESCRIPTION
## Summary
- add hourly forecast state, fetcher, and canvas rendering for temperature/precipitation and sunshine
- wire hourly loading into the daily forecast workflow and date picker change events
- ensure hourly charts clear gracefully when forecasts are unavailable and tweak canvas rendering quality

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de732a8bcc8322a427fc7798e68b0b