### PR TITLE
Fix weather forecast range for future dates

### DIFF
--- a/sunplanner.js
+++ b/sunplanner.js
@@ -3397,9 +3397,10 @@
       endRange=endDate.toISOString().slice(0,10);
     }
     var startRange=dateStr;
-    var todayIso=(new Date()).toISOString().slice(0,10);
     if(!startRange){ startRange=endRange; }
-    if(startRange && todayIso && startRange>todayIso){ startRange=todayIso; }
+    // Pozostaw zakres prognozy oparty na wybranej dacie, aby nie wykraczać poza limit 16 dni
+    // udostępniany przez Open-Meteo. Wcześniej przesuwaliśmy start na "dziś", co powodowało
+    // zapytania dłuższe niż dozwolone i błąd 400 przy wyborze przyszłych dni.
     if(startRange && endRange && startRange>endRange){ startRange=endRange; }
     var key=forecastKey(lat,lng,dateStr,startRange);
     var entry=forecastCache[key];


### PR DESCRIPTION
## Summary
- stop clamping Open-Meteo requests to today so the selected date defines the 16-day window
- avoid generating overlong forecast ranges that caused 400 errors for future days

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de7e27afb08322b0deab8bc19a752d