### PR TITLE
Prevent slider interactions from scrolling page

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -102,6 +102,9 @@ html,body{overflow-x:hidden}
 .glow-adjuster__label{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:#64748b;font-weight:700}
 .glow-adjuster__value{font-size:clamp(1.25rem,2.6vw,1.55rem);font-weight:700;color:#0f172a;line-height:1}
 .glow-adjuster__slider{flex:1 1 220px;min-width:180px;display:flex;flex-direction:column;gap:.45rem}
+/* Blokuj przewijanie rodzica podczas interakcji z suwakiem */
+.glow-adjuster,
+.glow-slider{overscroll-behavior:contain}
 .glow-slider{--slider-fill:50%;width:100%;-webkit-appearance:none;appearance:none;background:transparent;height:20px;margin:0;padding:0;touch-action:pan-x;cursor:pointer}
 .glow-slider:focus-visible{outline:3px solid rgba(233,66,68,.35);outline-offset:4px}
 .glow-slider::-webkit-slider-runnable-track{height:10px;border-radius:999px;background:linear-gradient(90deg,var(--accent) var(--slider-fill),#e5e7eb var(--slider-fill));box-shadow:inset 0 1px 0 rgba(255,255,255,.8)}


### PR DESCRIPTION
## Summary
- update the SunPlanner slider hook to prevent focus-induced scrolling and block wheel/keyboard from scrolling the document
- add overscroll-behavior containment to slider containers to avoid scroll chaining

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68de954356688322afbd3d0ae14590b2