### PR TITLE
Add time readouts to dawn and dusk sliders

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -100,8 +100,8 @@ html,body{overflow-x:hidden}
 .glow-adjuster{display:flex;align-items:center;gap:clamp(16px,3vw,24px);padding:.9rem 1.1rem;border-radius:18px;background:linear-gradient(135deg,rgba(248,250,252,.95),rgba(255,255,255,.95));border:1px solid #e2e8f0;box-shadow:inset 0 1px 0 rgba(255,255,255,.7);flex-wrap:wrap}
 .glow-adjuster__status{display:flex;flex-direction:column;gap:.2rem;min-width:140px}
 .glow-adjuster__label{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:#64748b;font-weight:700}
-.glow-adjuster__value{font-size:clamp(1.25rem,2.6vw,1.55rem);font-weight:700;color:#0f172a;line-height:1}
-.glow-adjuster__slider{flex:1 1 220px;min-width:180px;display:flex;flex-direction:column;gap:.45rem}
+.glow-adjuster__value{font-size:clamp(1.25rem,2.6vw,1.55rem);font-weight:700;color:#0f172a;line-height:1;display:inline-flex;align-items:center;font-variant-numeric:tabular-nums;min-width:4.8ch}
+.glow-adjuster__slider{flex:1 1 220px;min-width:180px;display:flex;flex-direction:column;gap:.45rem;position:relative}
 /* Blokada przewijania podczas interakcji z suwakiem */
 .glow-adjuster,
 .glow-adjuster__slider,
@@ -114,8 +114,19 @@ html,body{overflow-x:hidden}
 .glow-slider::-webkit-slider-thumb:hover{transform:scale(1.06);box-shadow:0 8px 20px rgba(233,66,68,.3)}
 .glow-slider::-moz-range-thumb{width:20px;height:20px;border-radius:50%;background:#fff;border:3px solid var(--accent);box-shadow:0 6px 16px rgba(233,66,68,.25);transition:transform .15s ease,box-shadow .2s ease}
 .glow-slider::-moz-range-thumb:hover{transform:scale(1.06);box-shadow:0 8px 20px rgba(233,66,68,.3)}
-.glow-slider__scale{display:flex;justify-content:space-between;font-size:.78rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:#94a3b8}
+.glow-slider-field{position:relative;width:100%;--slider-fill:50%;padding-top:2.3rem}
+.glow-slider-field .glow-slider{position:relative;z-index:2}
+.glow-slider__output{position:absolute;left:var(--slider-fill);top:0;transform:translate(-50%,-110%);background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:.35rem .55rem;box-shadow:0 10px 24px rgba(15,23,42,.12);display:flex;flex-direction:column;align-items:center;gap:.15rem;pointer-events:none;white-space:nowrap;font-size:.8rem;font-weight:600;color:#1f2937;font-variant-numeric:tabular-nums;transition:transform .2s ease,opacity .2s ease}
+.glow-slider__output::after{content:"";position:absolute;top:100%;left:50%;width:10px;height:10px;background:#fff;border-right:1px solid #e2e8f0;border-bottom:1px solid #e2e8f0;transform:translate(-50%,-5px) rotate(45deg);box-shadow:2px 2px 4px rgba(15,23,42,.06)}
+.glow-slider__output-value{font-weight:700;color:#0f172a}
+.glow-slider__output-time{font-size:.72rem;font-weight:500;color:#64748b}
+.glow-slider__scale{display:flex;justify-content:space-between;font-size:.78rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:#94a3b8;margin-top:.95rem}
 .glow-slider__scale span:nth-child(2){color:#475569}
+.glow-slider__scale span{white-space:nowrap}
+.glow-slider__output[hidden]{display:none}
+@media(max-width:600px){
+  .glow-slider-field{padding-top:2.6rem}
+}
 .slider{width:100%}
 .smallcanvas{width:100%;height:130px;border:1px solid #e5e7eb;border-radius:8px}
 


### PR DESCRIPTION
## Summary
- redesign the Świt and Zachód slider markup to include dedicated value/time outputs that keep the layout steady
- extend the slider hook logic to drive the new displays, update aria attributes, and prevent scroll jumps while moving the handle
- refresh slider styling so the new bubble readout is positioned via CSS variables and uses tabular numerals for stability

## Testing
- node -e "new Function(require('fs').readFileSync('sunplanner.js','utf8'))"

------
https://chatgpt.com/codex/tasks/task_e_68dea47552e08322ad27c2d367b0fee0