### PR TITLE
Stabilize Sun Planner slider link updates

### DIFF
--- a/sunplanner.css
+++ b/sunplanner.css
@@ -74,6 +74,7 @@ html,body{overflow-x:hidden}
 .route-card .alt-heading{margin:0}
 .grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:clamp(16px,3vw,32px)}
 .golden-block{display:grid;gap:clamp(20px,3vw,36px);margin-top:clamp(20px,3vw,36px)}
+.sun-section,.golden-block,.twilight-block{overscroll-behavior:contain}
 .glow-info{flex:none;width:100%;min-width:0;background:linear-gradient(135deg,rgba(253,230,138,.85),rgba(253,186,116,.85));border-radius:18px;padding:clamp(16px,3vw,24px);color:#78350f;display:flex;flex-direction:column;justify-content:center;align-items:flex-start;gap:clamp(8px,1.6vw,16px);box-shadow:0 4px 14px rgba(253,186,116,.25)}
 .glow-info.align-right{background:linear-gradient(135deg,rgba(191,219,254,.85),rgba(147,197,253,.85));color:#1e3a8a;text-align:right;align-items:flex-end}
 .glow-info h4{margin:0;font-size:clamp(1rem,2.2vw,1.15rem);font-weight:600}
@@ -164,6 +165,7 @@ html,body{overflow-x:hidden}
 #sp-short-status{margin-top:.75rem;font-size:.95rem;font-weight:700;color:#111}
 #sp-short-status strong{margin-right:.35rem}
 .share-row .btn{flex:1;min-width:160px}
+#sp-link{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
 #sp-short-status a{color:var(--accent);font-weight:700;text-decoration:none}
 #sp-short-status a:hover{color:#b91c1c;text-decoration:underline}
 .toolbar{justify-content:space-between;margin:.4rem 0 1rem}

--- a/sunplanner.js
+++ b/sunplanner.js
@@ -4454,13 +4454,6 @@
   dEl.addEventListener('change', function(){ updateDerived(); updateSunWeather(); });
 
   // suwaki
-  var debouncedRecalc = debounce(function(){
-    try {
-      updateSunWeather && updateSunWeather();
-      updateLink && updateLink();
-    } catch(_) {}
-  }, 180);
-
   function bindHourSlider(ringId, txtId, sliderId){
     var ring = document.getElementById(ringId);
     var txt  = document.getElementById(txtId);
@@ -4469,15 +4462,42 @@
 
     attachNoScrollHandlers(inp);
 
-    function apply(v){
-      var hours = Number(v) || 1;
+    var debouncedWeather = debounce(function(){
+      try {
+        updateSunWeather && updateSunWeather();
+      } catch(_) {}
+    }, 180);
+
+    var debouncedLink = debounce(function(){
+      try {
+        updateLink && updateLink();
+      } catch(_) {}
+    }, 900);
+
+    function updateUI(hours){
       applyRingProgress(ring, hours);
       txt.textContent = hours + ' h';
-      debouncedRecalc();
+      debouncedWeather();
     }
 
-    inp.addEventListener('input', function(e){ apply(e.target.value); }, { passive:true });
-    apply(inp.value);
+    function applyChange(){
+      try {
+        updateLink && updateLink();
+      } catch(_) {}
+    }
+
+    inp.addEventListener('input', function(e){
+      var hours = Number(e.target.value) || 1;
+      updateUI(hours);
+      debouncedLink();
+    }, { passive:true });
+
+    inp.addEventListener('change', applyChange);
+    inp.addEventListener('touchstart', function(e){ e.preventDefault(); }, { passive:false });
+
+    var initialHours = Number(inp.value) || 1;
+    updateUI(initialHours);
+    debouncedLink();
   }
 
   bindHourSlider('sp-ring-rise','sp-txt-rise','sp-slider-rise');


### PR DESCRIPTION
## Summary
- defer share link generation and URL updates until slider changes settle while keeping weather recalculation responsive
- add touchstart prevention and overscroll containment to reduce unwanted page scrolling during slider drags
- constrain the share link display to a single-line ellipsis so its height stays stable while dragging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df8979c20c83229996e02131a717bb