### PR TITLE
Preserve scroll position when updating planner URL

### DIFF
--- a/assets/js/sunplanner.js
+++ b/assets/js/sunplanner.js
@@ -4543,7 +4543,14 @@
     if (sliderDragging) return;
     var encodedState = b64url.enc(packState());
     var url = buildPlannerUrlFromEncoded(encodedState, urlRoleParam ? {role:urlRoleParam} : null);
-    history.replaceState(null,'',url);
+    if(url !== location.href){
+      var scrollX = (typeof window.scrollX === 'number') ? window.scrollX : window.pageXOffset || 0;
+      var scrollY = (typeof window.scrollY === 'number') ? window.scrollY : window.pageYOffset || 0;
+      history.replaceState(null,'',url);
+      if(typeof window.scrollTo === 'function'){
+        window.scrollTo(scrollX, scrollY);
+      }
+    }
     var linkEl=$('#sp-link'); if(linkEl) linkEl.textContent = url;
     if(shortLinkValue){
       if(shareId){


### PR DESCRIPTION
## Summary
- stop sunrise/sunset slider updates from janking the page by caching the current scroll coordinates
- only call `history.replaceState` when the generated planner URL actually differs and restore the previous scroll position immediately after

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df9e0610e0832289bd88b7efe75632