### PR TITLE
Replace sunrise and sunset sliders with segmented hour picker

### DIFF
--- a/assets/css/sunplanner.css
+++ b/assets/css/sunplanner.css
@@ -105,6 +105,13 @@ html,body{overflow-x:hidden}
 .ring{position:relative;display:inline-block;width:clamp(52px,10vw,68px);aspect-ratio:1/1;flex:0 0 auto}
 .ring svg{width:100%;height:100%}
 .ring .text{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);display:flex;align-items:center;justify-content:center;width:100%;height:100%;font-weight:600;font-size:clamp(.8rem,1.6vw,.95rem);line-height:1;text-align:center;pointer-events:none}
+.glow-duration{display:flex;align-items:center;gap:clamp(.8rem,2vw,1.4rem);flex-wrap:wrap}
+.glow-duration__options{flex:1;min-width:0;display:grid;grid-template-columns:repeat(auto-fit,minmax(52px,1fr));gap:.35rem}
+.glow-duration__option{border:1px solid #e5e7eb;border-radius:999px;padding:.45rem .5rem;font-weight:600;font-size:.9rem;line-height:1.1;background:#fff;color:#1f2937;cursor:pointer;transition:all .18s ease;text-align:center;box-shadow:0 2px 6px rgba(17,24,39,.06)}
+.glow-duration__option:hover,.glow-duration__option:focus-visible{border-color:var(--accent);color:#991b1b;box-shadow:0 6px 18px rgba(233,66,68,.15)}
+.glow-duration__option:focus-visible{outline:3px solid rgba(233,66,68,.35);outline-offset:2px}
+.glow-duration__option.is-active{background:var(--accent);color:#fff;border-color:var(--accent);box-shadow:0 8px 22px rgba(233,66,68,.25)}
+.glow-duration__option[tabindex="-1"]:focus{outline:none}
 .slider{
   -webkit-appearance:none;
   appearance:none;


### PR DESCRIPTION
## Summary
- replace the dawn and dusk hour sliders with button-based pickers that avoid scroll jumps while adjusting sleep time
- update state packing/unpacking and card rendering to use the new duration helpers
- add styling for the new controls and keep the share link constrained even for very long URLs

## Testing
- node -e "new Function(require('fs').readFileSync('assets/js/sunplanner.js','utf8'))"

------
https://chatgpt.com/codex/tasks/task_e_68dfa4517f5883228f0aa1d1d1aea8cb