### PR TITLE
Migrate Google Maps marker and autocomplete usage

### DIFF
--- a/assets/css/sunplanner.css
+++ b/assets/css/sunplanner.css
@@ -22,6 +22,8 @@ html,body{overflow-x:hidden}
 
 .col{display:flex;flex-direction:column}
 .input{flex:1;min-width:180px;padding:.55rem .7rem;border:1px solid #d1d5db;border-radius:.5rem;font-size:1rem}
+gmp-place-autocomplete,.sp-place-autocomplete{flex:1;min-width:180px;display:flex}
+gmp-place-autocomplete input{flex:1}
 .input.input-error{border-color:#f87171;box-shadow:0 0 0 1px rgba(248,113,113,.35)}
 
 .btn{padding:.55rem .9rem;border-radius:.5rem;border:1px solid var(--accent);background:var(--accent);color:#fff;cursor:pointer;transition:all .18s ease;font-weight:600;box-shadow:0 2px 6px rgba(233,66,68,.18)}

--- a/includes/class-sunplanner-frontend.php
+++ b/includes/class-sunplanner-frontend.php
@@ -25,7 +25,7 @@ class Frontend
         $key = 'AIzaSyDP0vhFiZV_yDB8urPJtQ4UdKQpAzmuOcU';
         $gmaps_src = 'https://maps.googleapis.com/maps/api/js?key='
             . \rawurlencode($key)
-            . '&libraries=places&language=pl&region=PL&v=weekly&loading=async&callback=initSunPlannerMap';
+            . '&libraries=marker,places&language=pl&region=PL&v=weekly&loading=async&callback=initSunPlannerMap';
 
         \wp_register_script('sunplanner-gmaps', $gmaps_src, [], null, true);
         if (\function_exists('wp_script_add_data')) {

--- a/sunplanner.php
+++ b/sunplanner.php
@@ -95,7 +95,7 @@ wp_add_inline_script('sunplanner-app', $stub, 'before');
 $key = 'AIzaSyDP0vhFiZV_yDB8urPJtQ4UdKQpAzmuOcU';
 $gmaps_src = 'https://maps.googleapis.com/maps/api/js?key='
 . rawurlencode($key)
-. '&libraries=places&language=pl&region=PL&v=weekly&loading=async&callback=initSunPlannerMap';
+. '&libraries=marker,places&language=pl&region=PL&v=weekly&loading=async&callback=initSunPlannerMap';
 
 
 wp_register_script('sunplanner-gmaps', $gmaps_src, [], null, true);


### PR DESCRIPTION
## Summary
- replace the draggable marker with AdvancedMarkerElement while keeping legacy Marker fallback
- migrate the Places autocomplete flow to the gmp-place-autocomplete element with legacy support
- load the marker library alongside places and tweak styles so the new component fits the existing layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfb3a735288322a7e4ebee1fe3c64d