### PR TITLE
Improve inspiration gallery navigation

### DIFF
--- a/assets/css/sunplanner.css
+++ b/assets/css/sunplanner.css
@@ -290,7 +290,8 @@ gmp-place-autocomplete input{flex:1}
 td .gallery-inspirations,th .gallery-inspirations{width:100%!important;max-width:100%!important;margin:0;padding:0}
 .gallery-track{position:relative}
 .inspiration-viewport{overflow:hidden;position:relative}
-.inspiration-track{display:flex;gap:12px;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;padding:6px 4px}
+.inspiration-track{display:flex;gap:12px;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;padding:6px 4px;scrollbar-width:none}
+.inspiration-track::-webkit-scrollbar{display:none}
 .inspiration-track:focus-visible{outline:2px solid rgba(15,23,42,.35);outline-offset:4px}
 .inspiration-track>.gallery-item{flex:0 0 auto;width:clamp(220px,30vw,360px);scroll-snap-align:start;border-radius:10px;overflow:hidden;margin:0}
 .gallery-item{min-width:0;margin:0}


### PR DESCRIPTION
## Summary
- hide the default scrollbar in the inspiration gallery track to keep the layout clean
- add gallery step calculation so the navigation arrows move exactly one photo at a time
- update navigation state tracking to reflect the new per-photo scrolling behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c7720c808322aa24c46bc45d40ad