### PR TITLE
Add grid lines to hourly weather chart

### DIFF
--- a/assets/css/sunplanner.css
+++ b/assets/css/sunplanner.css
@@ -197,10 +197,6 @@ gmp-place-autocomplete input{flex:1}
 .hourly-chart-area{flex:1 1 240px;min-width:0}
 #sp-hourly{width:100%;height:170px;min-height:170px;border:1px solid #e5e7eb;border-radius:10px;background:#fff}
 #sp-hourly,#sp-sunshine{image-rendering:-webkit-optimize-contrast}
-.hourly-temp-scale{flex:0 0 auto;display:flex;flex-direction:column;align-items:center;justify-content:space-between;padding:.75rem .5rem;border:1px solid #e5e7eb;border-radius:12px;background:#f9fafb;min-width:96px;text-align:center;gap:.5rem}
-.hourly-temp-scale__label{font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:#6b7280;line-height:1.2}
-.hourly-temp-scale__value{font-size:1.1rem;font-weight:700;color:#111827;display:inline-block}
-.hourly-temp-scale.is-empty .hourly-temp-scale__value{color:#9ca3af}
 .hourly-values{margin-top:.75rem;display:flex;flex-wrap:wrap;gap:.55rem;align-items:flex-end}
 .hourly-values--sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .hourly-values.is-empty{justify-content:center}


### PR DESCRIPTION
## Summary
- add horizontal temperature gridlines and vertical hour guides to the hourly forecast chart
- show temperature labels on both sides of the chart and remove the separate temperature range panel

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0ce93fe1c832289f664cd649415f3