### PR TITLE
Fix inspiration gallery fallbacks for missing Unsplash images

### DIFF
--- a/assets/js/sunplanner.js
+++ b/assets/js/sunplanner.js
@@ -4487,6 +4487,8 @@
       var headers={};
       if(UNSPLASH_KEY){
         headers.Authorization='Client-ID '+UNSPLASH_KEY;
+        headers['Accept-Version']='v1';
+        params.set('client_id', UNSPLASH_KEY);
       }
       function makePlaceholder(){
         return {

--- a/sunplanner.php
+++ b/sunplanner.php
@@ -120,6 +120,7 @@ wp_localize_script('sunplanner-app', 'SUNPLANNER_CFG', [
 'GMAPS_KEY' => $key,
 'CSE_ID' => 'b1d6737102d8e4107',
 'UNSPLASH_KEY' => 'OpKQ3jt1C2MKJW3v2U8jkhH0gWwBWj2w5BhoTxfa0tY',
+'ASSETS_URL' => trailingslashit(plugins_url('assets/', SUNPLANNER_FILE)),
 'TZ' => wp_timezone_string(),
 'SHARED_SP' => $shared_sp,
 'SHARE_ID' => $spid,


### PR DESCRIPTION
## Summary
- expose the assets directory URL to the SunPlanner front-end so fallback inspiration images can load
- update the Unsplash request to include the API client ID in both headers and query parameters for compatibility

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e110337ca88322a0a4e569436e6736