### PR TITLE
Improve SunPlanner landing page and plan titles

### DIFF
--- a/assets/css/sunplanner-landing.css
+++ b/assets/css/sunplanner-landing.css
@@ -292,6 +292,93 @@ body.sunplanner-landing a {
     font-size: 1.3rem;
 }
 
+.sunplanner-landing .planner-preview {
+    margin: clamp(4rem, 9vw, 7rem) 0 clamp(4rem, 9vw, 7rem);
+    padding: 0;
+}
+
+.sunplanner-landing .planner-preview__shell {
+    position: relative;
+}
+
+.sunplanner-landing .planner-preview__shell::before {
+    content: '';
+    position: absolute;
+    inset: -8%;
+    background: radial-gradient(circle at top left, rgba(242, 141, 183, 0.22), transparent 60%),
+        radial-gradient(circle at bottom right, rgba(121, 99, 255, 0.18), transparent 55%);
+    filter: blur(12px);
+    z-index: -1;
+}
+
+.sunplanner-landing .planner-preview__inner {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: clamp(2rem, 4vw, 3rem);
+    background: var(--bg-contrast);
+    border-radius: var(--radius-xl);
+    padding: clamp(2.5rem, 6vw, 3.5rem);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+}
+
+.sunplanner-landing .planner-preview__content h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.2rem, 4.5vw, 3.2rem);
+    line-height: 1.1;
+    margin: 1.25rem 0 1rem;
+}
+
+.sunplanner-landing .planner-preview__content p {
+    color: var(--muted);
+    margin: 0 0 1.25rem;
+}
+
+.sunplanner-landing .planner-preview__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.9rem;
+}
+
+.sunplanner-landing .planner-preview__list li {
+    position: relative;
+    padding-left: 1.9rem;
+    color: var(--text);
+    font-weight: 500;
+}
+
+.sunplanner-landing .planner-preview__list li::before {
+    content: '✓';
+    position: absolute;
+    left: 0;
+    top: 0.15rem;
+    width: 1.2rem;
+    height: 1.2rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+    color: #fff;
+    font-size: 0.75rem;
+    display: grid;
+    place-items: center;
+}
+
+.sunplanner-landing .planner-preview__app {
+    background: rgba(247, 246, 251, 0.65);
+    border-radius: var(--radius-lg);
+    padding: clamp(1.5rem, 4vw, 2rem);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.sunplanner-landing .planner-preview__app .sunplanner-wrap {
+    width: 100%;
+}
+
+.sunplanner-landing .planner-preview__app #sunplanner-app {
+    min-height: 640px;
+}
+
 .sunplanner-landing footer {
     padding: 3rem 0 4rem;
     color: var(--muted);
@@ -319,5 +406,17 @@ body.sunplanner-landing a {
 
     .sunplanner-landing .hero__media {
         padding: 1.25rem;
+    }
+
+    .sunplanner-landing .planner-preview__inner {
+        grid-template-columns: 1fr;
+    }
+
+    .sunplanner-landing .planner-preview__app {
+        padding: 1rem;
+    }
+
+    .sunplanner-landing .planner-preview__app #sunplanner-app {
+        min-height: 520px;
     }
 }

--- a/includes/class-sunplanner-rewrites.php
+++ b/includes/class-sunplanner-rewrites.php
@@ -81,7 +81,7 @@ class Rewrites
     public function filter_document_title(array $parts): array
     {
         if (\get_query_var('sunplan')) {
-            $parts['title'] = \__('Udostępniony plan – SunPlanner', 'sunplanner');
+            $parts['title'] = \__('Plan pleneru ślubnego – SunPlanner', 'sunplanner');
         }
 
         return $parts;

--- a/includes/class-sunplanner-share-page.php
+++ b/includes/class-sunplanner-share-page.php
@@ -53,7 +53,7 @@ class Sunplanner_Share_Page {
     public function filter_document_title_parts(array $parts): array
     {
         if ($this->is_share_request()) {
-            $parts['title'] = __('Udostępniony plan – SunPlanner', 'sunplanner');
+            $parts['title'] = __('Plan pleneru ślubnego – SunPlanner', 'sunplanner');
         }
 
         return $parts;

--- a/sunplanner.php
+++ b/sunplanner.php
@@ -1,8 +1,8 @@
 <?php
 /*
-Plugin Name: SunPlanner
+Plugin Name: SunPlanner – planer plenerów ślubnych
 Plugin URI: https://allemedia.pl/
-Description: Planer plenerów (złota/niebieska godzina, trasy, pogoda, eksporty).
+Description: Inteligentny planer plenerów ślubnych, który łączy pogodę, światło, logistykę i inspiracje w jednym miejscu.
 Version: 1.7.0
 Author: Allemedia
 Author URI: https://allemedia.pl/
@@ -117,7 +117,7 @@ function sunplanner_ensure_landing_page(): int
     }
 
     $page_data = [
-        'post_title'   => __('SunPlanner – zaplanuj plener ślubny', 'sunplanner'),
+        'post_title'   => __('SunPlanner – inteligentny planer plenerów ślubnych', 'sunplanner'),
         'post_name'    => 'sunplanner-landing',
         'post_status'  => 'publish',
         'post_type'    => 'page',
@@ -295,9 +295,9 @@ add_action('template_redirect', function () {
 
 add_filter('document_title_parts', function ($parts) {
     if (get_query_var('sunplan')) {
-        $parts['title'] = __('Udostępniony plan – SunPlanner', 'sunplanner');
+        $parts['title'] = __('Plan pleneru ślubnego – SunPlanner', 'sunplanner');
     } elseif (sunplanner_is_landing_page()) {
-        $parts['title'] = __('SunPlanner – zaplanuj plener ślubny', 'sunplanner');
+        $parts['title'] = __('SunPlanner – inteligentny planer plenerów ślubnych', 'sunplanner');
     }
 
     return $parts;

--- a/templates/landing.php
+++ b/templates/landing.php
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 <head>
     <meta charset="<?php bloginfo('charset'); ?>" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title><?php echo esc_html__('SunPlanner – zaplanuj plener ślubny', 'sunplanner'); ?></title>
+    <title><?php echo esc_html__('SunPlanner – inteligentny planer plenerów ślubnych', 'sunplanner'); ?></title>
     <?php wp_head(); ?>
 </head>
 <body <?php body_class('sunplanner-landing'); ?>>
@@ -22,21 +22,21 @@ if (!defined('ABSPATH')) {
     <div class="page-shell">
         <section class="hero">
             <div>
-                <span class="hero__badge">Dla Młodych Par i ekip foto-video</span>
-                <h1 class="hero__title">Wasz plener ślubny, zaplanowany co do promyka słońca</h1>
-                <p class="hero__subtitle">SunPlanner pomaga zsynchronizować pogodę, światło i logistykę tak, by dzień pleneru był czystą przyjemnością – bez gonitwy, bez zgadywania.</p>
-                <a class="hero__cta" href="#jak-to-dziala">Zobacz jak działa SunPlanner →</a>
+                <span class="hero__badge">SunPlanner dla Par Młodych i ekip foto-video</span>
+                <h1 class="hero__title">Inteligentny planer plenerów ślubnych gotowy na każdą aurę</h1>
+                <p class="hero__subtitle">Od wyboru lokalizacji po złotą godzinę i logistykę dojazdu – SunPlanner prowadzi Was krok po kroku, aby plener był dopięty na ostatni promyk światła.</p>
+                <a class="hero__cta" href="#sunplanner-live">Przejdź do planera →</a>
             </div>
             <div class="hero__media">
                 <div class="hero__card">
-                    <h3>Wasz dzień w skrócie</h3>
+                    <h3>Plan dnia w skrócie</h3>
                     <strong>Plener 17:45</strong>
                     <div>
                         <p><strong>Złota godzina:</strong> 18:12 – 18:54</p>
                         <p><strong>Prognoza:</strong> Słonecznie, 22°C, wiatr 8 km/h</p>
                         <p><strong>Trasa:</strong> 42 min z Pałacu Czosnów do Kampinosu</p>
                     </div>
-                    <p style="margin: 0; font-size: 0.85rem; color: var(--muted);">Plan udostępniony ekipie foto-video i kierowcy jednym kliknięciem.</p>
+                    <p style="margin: 0; font-size: 0.85rem; color: var(--muted);">Plan udostępniony Parze, fotografowi, filmowcowi i kierowcy jednym kliknięciem.</p>
                 </div>
             </div>
         </section>
@@ -129,6 +129,26 @@ if (!defined('ABSPATH')) {
                         <p>Poranne mgły, wiatr we włosach i ciepłe pledy na plaży.</p>
                     </div>
                 </article>
+            </div>
+        </section>
+
+        <section class="planner-preview" id="sunplanner-live">
+            <div class="page-shell planner-preview__shell">
+                <div class="planner-preview__inner">
+                    <div class="planner-preview__content">
+                        <span class="eyebrow">Wypróbuj teraz</span>
+                        <h2>Ułóż pierwszy plan pleneru w kilku minutach</h2>
+                        <p>SunPlanner łączy prognozę pogody, złote i niebieskie godziny oraz logistykę przejazdów w jednym przejrzystym widoku. Poniżej działa w pełni funkcjonalna wersja planera gotowa do testów.</p>
+                        <ul class="planner-preview__list">
+                            <li>Sprawdź natychmiast prognozę 16-dniową, radar i warunki świetlne dla wybranej lokalizacji.</li>
+                            <li>Zbuduj trasę z kilkoma przystankami i zobacz, ile czasu naprawdę zajmie cała sesja.</li>
+                            <li>Udostępnij plan Parze, fotografowi i filmowcowi jako link, PDF lub zapis w kalendarzu.</li>
+                        </ul>
+                    </div>
+                    <div class="planner-preview__app">
+                        <?php echo do_shortcode('[sunplanner]'); ?>
+                    </div>
+                </div>
             </div>
         </section>
     </div>

--- a/templates/share.php
+++ b/templates/share.php
@@ -15,9 +15,9 @@ get_header();
 <main id="primary" class="sunplanner-share">
     <div class="sunplanner-share__inner">
         <header class="sunplanner-share__header">
-            <span class="sunplanner-share__badge">SunPlanner</span>
-            <h1 class="sunplanner-share__title">Udostępniony plan zdjęciowy</h1>
-            <p class="sunplanner-share__desc">Poniżej znajdziesz zapisany plan dnia wraz z mapą, pogodą i kluczowymi godzinami przygotowany w aplikacji SunPlanner.</p>
+            <span class="sunplanner-share__badge">SunPlanner – planer plenerów ślubnych</span>
+            <h1 class="sunplanner-share__title">Plan pleneru ślubnego przygotowany dla Waszej ekipy</h1>
+            <p class="sunplanner-share__desc">Znajdziesz tu harmonogram światła, pogodę, trasę i notatki zebrane w SunPlannerze. Korzystaj na dowolnym urządzeniu i miej pewność, że wszyscy widzą te same aktualne dane.</p>
         </header>
 
         <?php echo do_shortcode('[sunplanner]'); ?>


### PR DESCRIPTION
## Summary
- update plugin metadata and document titles to highlight SunPlanner as an intelligent wedding outdoor planner
- overhaul the landing template with a marketing hero and embedded planner preview so users see the benefits before using the tool
- refresh shared-plan copy and styling to better explain what recipients receive

## Testing
- php -l sunplanner.php
- php -l templates/landing.php
- php -l templates/share.php
- php -l includes/class-sunplanner-share-page.php
- php -l includes/class-sunplanner-rewrites.php

------
https://chatgpt.com/codex/tasks/task_e_68e21d78d00883228372f479d1792dc3