### PR TITLE
Add introductory block above planner

### DIFF
--- a/assets/css/sunplanner.css
+++ b/assets/css/sunplanner.css
@@ -4,6 +4,33 @@
 html,body{overflow-x:hidden}
 .sunplanner-wrap{width:100%}
 
+.sunplanner-intro{position:relative;margin:0 0 clamp(32px,6vw,56px);padding:clamp(28px,6vw,48px);border-radius:32px;background:linear-gradient(135deg,rgba(254,243,199,.92),rgba(255,255,255,.95));box-shadow:0 24px 55px rgba(15,23,42,.08);overflow:hidden}
+.sunplanner-intro::after{content:"";position:absolute;inset:auto -18% -40% auto;width:280px;height:280px;border-radius:999px;background:radial-gradient(circle at center,rgba(233,66,68,.16),transparent 70%);transform:rotate(18deg)}
+.sunplanner-intro__inner>.vc_column-inner>.wpb_wrapper{position:relative;z-index:1}
+.sunplanner-intro__badge{display:inline-flex;align-items:center;gap:.35rem;padding:.35rem .85rem;border-radius:999px;background:rgba(233,66,68,.08);color:#b91c1c;font-weight:600;letter-spacing:.08em;text-transform:uppercase;font-size:.78rem}
+.sunplanner-intro__title{margin:clamp(12px,2vw,18px) 0 clamp(6px,1.2vw,10px);font-size:clamp(2.1rem,4vw,2.85rem);line-height:1.15;color:#0f172a;font-weight:700}
+.sunplanner-intro__lead{margin:0 0 clamp(10px,1.8vw,16px);font-size:clamp(1.05rem,2.3vw,1.25rem);color:#1f2937;font-weight:500;max-width:760px}
+.sunplanner-intro__text{margin:0 0 clamp(22px,4vw,32px);font-size:clamp(.95rem,1.9vw,1.05rem);color:#475569;max-width:820px}
+.sunplanner-intro__features{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:clamp(18px,3.8vw,28px);margin:clamp(22px,4vw,32px) 0 clamp(10px,2vw,18px)}
+.sunplanner-intro__feature{display:flex;flex-direction:column;gap:clamp(10px,2vw,16px);padding:clamp(20px,4vw,28px);border-radius:24px;background:#fff;box-shadow:0 18px 40px rgba(15,23,42,.08);min-height:0}
+.sunplanner-intro__icon{display:inline-flex;align-items:center;justify-content:center;width:64px;height:64px;border-radius:18px;background:linear-gradient(135deg,rgba(233,66,68,.15),rgba(233,66,68,.05));color:var(--accent);box-shadow:0 12px 26px rgba(233,66,68,.18)}
+.sunplanner-intro__icon svg{width:32px;height:32px}
+.sunplanner-intro__feature h3{margin:0;font-size:clamp(1.05rem,2.1vw,1.35rem);color:#0f172a;font-weight:600}
+.sunplanner-intro__feature p{margin:0;font-size:clamp(.92rem,1.8vw,1.02rem);color:#4b5563;line-height:1.55}
+.sunplanner-intro__cta-wrapper{display:flex;flex-wrap:wrap;align-items:center;gap:clamp(12px,2.5vw,20px);margin-top:clamp(12px,2vw,20px)}
+.sunplanner-intro__cta{padding:.75rem 1.7rem;border-radius:999px;font-size:1.05rem;font-weight:600;box-shadow:0 10px 22px rgba(233,66,68,.2)}
+.sunplanner-intro__hint{font-size:.95rem;color:#475569}
+.sunplanner-intro__hint strong{color:#111}
+@media(max-width:767px){
+  .sunplanner-intro{padding:clamp(24px,7vw,36px);border-radius:26px}
+  .sunplanner-intro__cta{width:100%;text-align:center}
+  .sunplanner-intro__hint{width:100%;text-align:center}
+}
+@media(max-width:560px){
+  .sunplanner-intro__icon{width:56px;height:56px;border-radius:16px}
+  .sunplanner-intro__icon svg{width:28px;height:28px}
+}
+
 .sunplanner{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;color:#111;line-height:1.45}
 .sunplanner-share{min-height:60vh}
 @supports (min-height: 60svh){

--- a/includes/class-sunplanner-frontend.php
+++ b/includes/class-sunplanner-frontend.php
@@ -95,6 +95,7 @@ class Frontend
         \wp_enqueue_script('sunplanner-gmaps');
 
         \ob_start();
+        echo \sunplanner_get_intro_block();
         ?>
         <div id="sunplanner-app" class="sunplanner-wrap" data-version="<?php echo \esc_attr(defined('SUNPLANNER_VERSION') ? SUNPLANNER_VERSION : ''); ?>"></div>
         <?php

--- a/sunplanner.php
+++ b/sunplanner.php
@@ -251,14 +251,82 @@ return $html;
 }, 10, 4);
 
 
+if (!function_exists('sunplanner_get_intro_block')) {
+    function sunplanner_get_intro_block(): string
+    {
+        ob_start();
+        ?>
+        <div class="sunplanner-intro vc_row wpb_row vc_row-fluid">
+            <div class="sunplanner-intro__inner wpb_column vc_column_container vc_col-sm-12">
+                <div class="vc_column-inner">
+                    <div class="wpb_wrapper">
+                        <span class="sunplanner-intro__badge"><?php echo esc_html__('Poznaj SunPlanner', 'sunplanner'); ?></span>
+                        <h2 class="sunplanner-intro__title"><?php echo esc_html__('Zaplanuj swoje plenerowe sesje z SunPlannerem', 'sunplanner'); ?></h2>
+                        <p class="sunplanner-intro__lead"><?php echo esc_html__('SunPlanner zbiera w jednym miejscu prognozy światła, pogodę i logistykę, dzięki czemu w kilka minut przygotujesz kompletny scenariusz pleneru ślubnego.', 'sunplanner'); ?></p>
+                        <p class="sunplanner-intro__text"><?php echo esc_html__('Wypełnij planer poniżej, aby dobrać najlepsze lokalizacje, godziny „złotej godziny” oraz listę zadań do współdzielenia z zespołem.', 'sunplanner'); ?></p>
+                        <div class="sunplanner-intro__features vc_row wpb_row vc_row-fluid">
+                            <div class="sunplanner-intro__feature">
+                                <span class="sunplanner-intro__icon" aria-hidden="true">
+                                    <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                                        <rect x="9" y="14" width="30" height="24" rx="4"></rect>
+                                        <path d="M16 10v8M32 10v8"></path>
+                                        <path d="M9 20h30"></path>
+                                        <circle cx="24" cy="30" r="5"></circle>
+                                    </svg>
+                                </span>
+                                <h3><?php echo esc_html__('Harmonogram światła i pogody', 'sunplanner'); ?></h3>
+                                <p><?php echo esc_html__('Zestaw prognozę światła, zachmurzenie i temperaturę, aby znaleźć idealne okno na sesję.', 'sunplanner'); ?></p>
+                            </div>
+                            <div class="sunplanner-intro__feature">
+                                <span class="sunplanner-intro__icon" aria-hidden="true">
+                                    <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                                        <rect x="10" y="10" width="28" height="28" rx="6"></rect>
+                                        <path d="M17 20h14"></path>
+                                        <path d="M17 26h10"></path>
+                                        <path d="M17 32h6"></path>
+                                        <path d="M15 20l2.6 2.6 4.4-4.4"></path>
+                                    </svg>
+                                </span>
+                                <h3><?php echo esc_html__('Lista zadań i przypomnienia', 'sunplanner'); ?></h3>
+                                <p><?php echo esc_html__('Notuj logistykę, akcesoria i punkty programu, aby nic nie umknęło w dniu sesji.', 'sunplanner'); ?></p>
+                            </div>
+                            <div class="sunplanner-intro__feature">
+                                <span class="sunplanner-intro__icon" aria-hidden="true">
+                                    <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                                        <circle cx="18" cy="20" r="6"></circle>
+                                        <circle cx="32" cy="18" r="5"></circle>
+                                        <path d="M8 36c0-5.5 4.5-10 10-10s10 4.5 10 10"></path>
+                                        <path d="M30 30c1.5-2.4 4.4-4 7.5-4 3.5 0 6.5 1.9 8.5 4.9"></path>
+                                    </svg>
+                                </span>
+                                <h3><?php echo esc_html__('Współdzielone notatki i eksport', 'sunplanner'); ?></h3>
+                                <p><?php echo esc_html__('Udostępnij gotowy plan parze i ekipie, eksportuj PDF lub link, by wszyscy byli na bieżąco.', 'sunplanner'); ?></p>
+                            </div>
+                        </div>
+                        <div class="sunplanner-intro__cta-wrapper">
+                            <a class="btn sunplanner-intro__cta" href="<?php echo esc_url('#sunplanner-app'); ?>"><?php echo esc_html__('Rozpocznij planowanie', 'sunplanner'); ?></a>
+                            <span class="sunplanner-intro__hint"><?php echo esc_html__('Zacznij od sekcji poniżej lub przewiń, aby sprawdzić zapisane inspiracje.', 'sunplanner'); ?></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <?php
+        return (string) ob_get_clean();
+    }
+}
+
+
 /** === Shortcode === */
 add_shortcode('sunplanner', function () {
-wp_enqueue_style('sunplanner-css');
-wp_enqueue_script('sunplanner-app');
+    wp_enqueue_style('sunplanner-css');
+    wp_enqueue_script('sunplanner-app');
     wp_enqueue_script('sunplanner-gmaps');
-    ob_start(); ?>
-<div id="sunplanner-app" class="sunplanner-wrap" data-version="1.7.5"></div>
-<?php return ob_get_clean();
+    ob_start();
+    echo sunplanner_get_intro_block();
+    ?>
+    <div id="sunplanner-app" class="sunplanner-wrap" data-version="1.7.5"></div>
+    <?php return ob_get_clean();
 });
 
 


### PR DESCRIPTION
## Summary
- add a reusable SunPlanner intro block that renders before the planner via the shortcode implementation
- style the new introduction section to match the existing landing visuals and highlight key planner features

## Testing
- php -l sunplanner.php
- php -l includes/class-sunplanner-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68e291dd5cf48322a286c2c1669ea0f9